### PR TITLE
Created App Blocking Logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ Package.resolved
 .env
 .env.*
 *.local
+focus-lock/Config/Local.xcconfig

--- a/focus-lock/Config/Local.example.xcconfig
+++ b/focus-lock/Config/Local.example.xcconfig
@@ -1,0 +1,5 @@
+// Copy this file to Local.xcconfig and replace the values with your Apple
+// Developer account settings. Local.xcconfig is ignored by Git.
+
+DEVELOPMENT_TEAM = YOUR_TEAM_ID
+APP_BUNDLE_ID = com.yourname.focuslock

--- a/focus-lock/Config/Shared.xcconfig
+++ b/focus-lock/Config/Shared.xcconfig
@@ -1,0 +1,9 @@
+// Shared signing defaults.
+//
+// These values keep the project buildable after a fresh checkout. Each developer
+// can override them in Local.xcconfig without committing personal signing changes.
+
+DEVELOPMENT_TEAM = TGK2CZ6QA4
+APP_BUNDLE_ID = com.focuslock.focuslock-app
+
+#include? "Local.xcconfig"

--- a/focus-lock/FocusLockShieldConfiguration/FocusLockShieldConfiguration.entitlements
+++ b/focus-lock/FocusLockShieldConfiguration/FocusLockShieldConfiguration.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>com.apple.developer.family-controls</key>
+        <true/>
+    </dict>
+</plist>

--- a/focus-lock/FocusLockShieldConfiguration/Info.plist
+++ b/focus-lock/FocusLockShieldConfiguration/Info.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.ManagedSettingsUI.shield-configuration-service</string>
+		<key>NSExtensionPrincipalClass</key>
+		<string>$(PRODUCT_MODULE_NAME).ShieldConfigurationExtension</string>
+	</dict>
+</dict>
+</plist>

--- a/focus-lock/FocusLockShieldConfiguration/Info.plist
+++ b/focus-lock/FocusLockShieldConfiguration/Info.plist
@@ -2,12 +2,40 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>NSExtension</key>
-	<dict>
-		<key>NSExtensionPointIdentifier</key>
-		<string>com.apple.ManagedSettingsUI.shield-configuration-service</string>
-		<key>NSExtensionPrincipalClass</key>
-		<string>$(PRODUCT_MODULE_NAME).ShieldConfigurationExtension</string>
-	</dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>$(DEVELOPMENT_LANGUAGE)</string>
+
+    <key>CFBundleDisplayName</key>
+    <string>FocusLockShieldConfiguration</string>
+
+    <key>CFBundleExecutable</key>
+    <string>$(EXECUTABLE_NAME)</string>
+
+    <key>CFBundleIdentifier</key>
+    <string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+
+    <key>CFBundleName</key>
+    <string>$(PRODUCT_NAME)</string>
+
+    <key>CFBundlePackageType</key>
+    <string>XPC!</string>
+
+    <key>CFBundleShortVersionString</key>
+    <string>1.0</string>
+
+    <key>CFBundleVersion</key>
+    <string>1</string>
+
+    <key>NSExtension</key>
+    <dict>
+        <key>NSExtensionPointIdentifier</key>
+        <string>com.apple.ManagedSettingsUI.shield-configuration-service</string>
+
+        <key>NSExtensionPrincipalClass</key>
+        <string>$(PRODUCT_MODULE_NAME).ShieldConfigurationExtension</string>
+    </dict>
 </dict>
 </plist>

--- a/focus-lock/FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
+++ b/focus-lock/FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
@@ -1,0 +1,58 @@
+//
+//  ShieldConfigurationExtension.swift
+//  FocusLockShieldConfiguration
+//
+//  Created by Suraj Modur on 5/8/26.
+//
+
+import ManagedSettings
+import ManagedSettingsUI
+import UIKit
+
+// Override the functions below to customize the shields used in various situations.
+// The system provides a default appearance for any methods that your subclass doesn't override.
+// Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
+class ShieldConfigurationExtension: ShieldConfigurationDataSource {
+    // iOS calls this when the user opens an app that Focus Lock has shielded.
+    // This config controls the system blocked screen shown over that app.
+    override func configuration(shielding application: Application) -> ShieldConfiguration {
+
+        return ShieldConfiguration(
+            // Matches the title currently shown in BlockedView.
+            title: .init(
+                text: "App is blocked",
+                color: .label
+            ),
+
+            // Adds a short explanation because shield screens support a subtitle area.
+            subtitle: .init(
+                text: "Focus Lock is keeping you away from this app.",
+                color: .secondaryLabel
+            ),
+
+            // Matches the button currently shown in BlockedView.
+            primaryButtonLabel: .init(
+                text: "Pay $5 to unlock",
+                color: .white
+            ),
+
+            // Makes the primary action look like a real call-to-action button.
+            primaryButtonBackgroundColor: .systemBlue
+        )
+    }
+    
+    override func configuration(shielding application: Application, in category: ActivityCategory) -> ShieldConfiguration {
+        // Customize the shield as needed for applications shielded because of their category.
+        ShieldConfiguration()
+    }
+    
+    override func configuration(shielding webDomain: WebDomain) -> ShieldConfiguration {
+        // Customize the shield as needed for web domains.
+        ShieldConfiguration()
+    }
+    
+    override func configuration(shielding webDomain: WebDomain, in category: ActivityCategory) -> ShieldConfiguration {
+        // Customize the shield as needed for web domains shielded because of their category.
+        ShieldConfiguration()
+    }
+}

--- a/focus-lock/focus-lock.xcodeproj/project.pbxproj
+++ b/focus-lock/focus-lock.xcodeproj/project.pbxproj
@@ -375,7 +375,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 6326888VVQ;
+				DEVELOPMENT_TEAM = TGK2CZ6QA4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "focus-lock";
@@ -390,7 +390,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.focuslock.focuslockapp;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -412,7 +412,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 6326888VVQ;
+				DEVELOPMENT_TEAM = TGK2CZ6QA4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "focus-lock";
@@ -427,7 +427,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = com.focuslock.focuslockapp;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -437,6 +437,35 @@
 				SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		F173EDE62FAFD0260012076D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEVELOPMENT_TEAM = TGK2CZ6QA4;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = FocusLockShieldConfiguration/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app.FocusLockShieldConfiguration";
+				PRODUCT_NAME = FocusLockShieldConfiguration;
+				SWIFT_VERSION = 5.0;
+			};
+			name = Debug;
+		};
+		F173EDE72FAFD0260012076D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = YES;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEVELOPMENT_TEAM = TGK2CZ6QA4;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = FocusLockShieldConfiguration/Info.plist;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app.FocusLockShieldConfiguration";
+				PRODUCT_NAME = FocusLockShieldConfiguration;
+				SWIFT_VERSION = 5.0;
 			};
 			name = Release;
 		};
@@ -464,8 +493,8 @@
 		F173ED592FAE639A0012076D /* Build configuration list for PBXNativeTarget "FocusLockShieldConfiguration" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				F173ED562FAE639A0012076D /* Debug */,
-				F173ED572FAE639A0012076D /* Release */,
+				F173EDE62FAFD0260012076D /* Debug */,
+				F173EDE72FAFD0260012076D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/focus-lock/focus-lock.xcodeproj/project.pbxproj
+++ b/focus-lock/focus-lock.xcodeproj/project.pbxproj
@@ -6,14 +6,65 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		F173ED4A2FAE639A0012076D /* ManagedSettings.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F173ED492FAE639A0012076D /* ManagedSettings.framework */; };
+		F173ED4C2FAE639A0012076D /* ManagedSettingsUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F173ED4B2FAE639A0012076D /* ManagedSettingsUI.framework */; };
+		F173ED542FAE639A0012076D /* FocusLockShieldConfiguration.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F173ED472FAE63990012076D /* FocusLockShieldConfiguration.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+/* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F173ED522FAE639A0012076D /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 71209C192F1429F3008313C6 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F173ED462FAE63990012076D;
+			remoteInfo = FocusLockShieldConfiguration;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		F173ED552FAE639A0012076D /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				F173ED542FAE639A0012076D /* FocusLockShieldConfiguration.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		71209C212F1429F3008313C6 /* focus-lock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "focus-lock.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F173ED472FAE63990012076D /* FocusLockShieldConfiguration.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FocusLockShieldConfiguration.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		F173ED492FAE639A0012076D /* ManagedSettings.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ManagedSettings.framework; path = System/Library/Frameworks/ManagedSettings.framework; sourceTree = SDKROOT; };
+		F173ED4B2FAE639A0012076D /* ManagedSettingsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ManagedSettingsUI.framework; path = System/Library/Frameworks/ManagedSettingsUI.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		F173ED582FAE639A0012076D /* Exceptions for "FocusLockShieldConfiguration" folder in "FocusLockShieldConfiguration" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = F173ED462FAE63990012076D /* FocusLockShieldConfiguration */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		71209C232F1429F3008313C6 /* focus-lock */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			path = "focus-lock";
+			sourceTree = "<group>";
+		};
+		F173ED4D2FAE639A0012076D /* FocusLockShieldConfiguration */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				F173ED582FAE639A0012076D /* Exceptions for "FocusLockShieldConfiguration" folder in "FocusLockShieldConfiguration" target */,
+			);
+			path = FocusLockShieldConfiguration;
 			sourceTree = "<group>";
 		};
 /* End PBXFileSystemSynchronizedRootGroup section */
@@ -26,6 +77,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F173ED442FAE63990012076D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F173ED4A2FAE639A0012076D /* ManagedSettings.framework in Frameworks */,
+				F173ED4C2FAE639A0012076D /* ManagedSettingsUI.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -33,6 +93,8 @@
 			isa = PBXGroup;
 			children = (
 				71209C232F1429F3008313C6 /* focus-lock */,
+				F173ED4D2FAE639A0012076D /* FocusLockShieldConfiguration */,
+				F173ED482FAE639A0012076D /* Frameworks */,
 				71209C222F1429F3008313C6 /* Products */,
 			);
 			sourceTree = "<group>";
@@ -41,8 +103,18 @@
 			isa = PBXGroup;
 			children = (
 				71209C212F1429F3008313C6 /* focus-lock.app */,
+				F173ED472FAE63990012076D /* FocusLockShieldConfiguration.appex */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		F173ED482FAE639A0012076D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F173ED492FAE639A0012076D /* ManagedSettings.framework */,
+				F173ED4B2FAE639A0012076D /* ManagedSettingsUI.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -55,10 +127,12 @@
 				71209C1D2F1429F3008313C6 /* Sources */,
 				71209C1E2F1429F3008313C6 /* Frameworks */,
 				71209C1F2F1429F3008313C6 /* Resources */,
+				F173ED552FAE639A0012076D /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				F173ED532FAE639A0012076D /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
 				71209C232F1429F3008313C6 /* focus-lock */,
@@ -69,6 +143,28 @@
 			productName = "focus-lock";
 			productReference = 71209C212F1429F3008313C6 /* focus-lock.app */;
 			productType = "com.apple.product-type.application";
+		};
+		F173ED462FAE63990012076D /* FocusLockShieldConfiguration */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F173ED592FAE639A0012076D /* Build configuration list for PBXNativeTarget "FocusLockShieldConfiguration" */;
+			buildPhases = (
+				F173ED432FAE63990012076D /* Sources */,
+				F173ED442FAE63990012076D /* Frameworks */,
+				F173ED452FAE63990012076D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				F173ED4D2FAE639A0012076D /* FocusLockShieldConfiguration */,
+			);
+			name = FocusLockShieldConfiguration;
+			packageProductDependencies = (
+			);
+			productName = FocusLockShieldConfiguration;
+			productReference = F173ED472FAE63990012076D /* FocusLockShieldConfiguration.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 /* End PBXNativeTarget section */
 
@@ -81,6 +177,9 @@
 				LastUpgradeCheck = 2620;
 				TargetAttributes = {
 					71209C202F1429F3008313C6 = {
+						CreatedOnToolsVersion = 26.2;
+					};
+					F173ED462FAE63990012076D = {
 						CreatedOnToolsVersion = 26.2;
 					};
 				};
@@ -100,12 +199,20 @@
 			projectRoot = "";
 			targets = (
 				71209C202F1429F3008313C6 /* focus-lock */,
+				F173ED462FAE63990012076D /* FocusLockShieldConfiguration */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
 		71209C1F2F1429F3008313C6 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F173ED452FAE63990012076D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -122,7 +229,22 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F173ED432FAE63990012076D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F173ED532FAE639A0012076D /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F173ED462FAE63990012076D /* FocusLockShieldConfiguration */;
+			targetProxy = F173ED522FAE639A0012076D /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		71209C2A2F1429F4008313C6 /* Debug */ = {
@@ -335,6 +457,15 @@
 			buildConfigurations = (
 				71209C2D2F1429F4008313C6 /* Debug */,
 				71209C2E2F1429F4008313C6 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F173ED592FAE639A0012076D /* Build configuration list for PBXNativeTarget "FocusLockShieldConfiguration" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F173ED562FAE639A0012076D /* Debug */,
+				F173ED572FAE639A0012076D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/focus-lock/focus-lock.xcodeproj/project.pbxproj
+++ b/focus-lock/focus-lock.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 
 /* Begin PBXFileReference section */
 		71209C212F1429F3008313C6 /* focus-lock.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "focus-lock.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		71209C302F1429F4008313C6 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
+		71209C312F1429F4008313C6 /* Local.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.example.xcconfig; sourceTree = "<group>"; };
+		71209C332F1429F4008313C6 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
 		F173ED472FAE63990012076D /* FocusLockShieldConfiguration.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FocusLockShieldConfiguration.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		F173ED492FAE639A0012076D /* ManagedSettings.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ManagedSettings.framework; path = System/Library/Frameworks/ManagedSettings.framework; sourceTree = SDKROOT; };
 		F173ED4B2FAE639A0012076D /* ManagedSettingsUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ManagedSettingsUI.framework; path = System/Library/Frameworks/ManagedSettingsUI.framework; sourceTree = SDKROOT; };
@@ -92,11 +95,22 @@
 		71209C182F1429F3008313C6 = {
 			isa = PBXGroup;
 			children = (
+				71209C322F1429F4008313C6 /* Config */,
 				71209C232F1429F3008313C6 /* focus-lock */,
 				F173ED4D2FAE639A0012076D /* FocusLockShieldConfiguration */,
 				F173ED482FAE639A0012076D /* Frameworks */,
 				71209C222F1429F3008313C6 /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		71209C322F1429F4008313C6 /* Config */ = {
+			isa = PBXGroup;
+			children = (
+				71209C302F1429F4008313C6 /* Shared.xcconfig */,
+				71209C312F1429F4008313C6 /* Local.example.xcconfig */,
+				71209C332F1429F4008313C6 /* Local.xcconfig */,
+			);
+			path = Config;
 			sourceTree = "<group>";
 		};
 		71209C222F1429F3008313C6 /* Products */ = {
@@ -368,6 +382,7 @@
 		};
 		71209C2D2F1429F4008313C6 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71209C302F1429F4008313C6 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -375,7 +390,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = TGK2CZ6QA4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "focus-lock";
@@ -390,7 +404,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -405,6 +419,7 @@
 		};
 		71209C2E2F1429F4008313C6 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71209C302F1429F4008313C6 /* Shared.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
@@ -412,7 +427,6 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = TGK2CZ6QA4;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "focus-lock";
@@ -427,7 +441,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -442,14 +456,14 @@
 		};
 		F173EDE62FAFD0260012076D /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71209C302F1429F4008313C6 /* Shared.xcconfig */;
 			buildSettings = {
 				COPY_PHASE_STRIP = NO;
-				DEVELOPMENT_TEAM = TGK2CZ6QA4;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = FocusLockShieldConfiguration/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app.FocusLockShieldConfiguration";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).FocusLockShieldConfiguration";
 				PRODUCT_NAME = FocusLockShieldConfiguration;
 				SWIFT_VERSION = 5.0;
 			};
@@ -457,13 +471,13 @@
 		};
 		F173EDE72FAFD0260012076D /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 71209C302F1429F4008313C6 /* Shared.xcconfig */;
 			buildSettings = {
 				COPY_PHASE_STRIP = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
-				DEVELOPMENT_TEAM = TGK2CZ6QA4;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = FocusLockShieldConfiguration/Info.plist;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.focuslock.focuslock-app.FocusLockShieldConfiguration";
+				PRODUCT_BUNDLE_IDENTIFIER = "$(APP_BUNDLE_ID).FocusLockShieldConfiguration";
 				PRODUCT_NAME = FocusLockShieldConfiguration;
 				SWIFT_VERSION = 5.0;
 			};

--- a/focus-lock/focus-lock.xcodeproj/xcshareddata/xcschemes/focus-lock.xcscheme
+++ b/focus-lock/focus-lock.xcodeproj/xcshareddata/xcschemes/focus-lock.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2640"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "71209C202F1429F3008313C6"
+               BuildableName = "focus-lock.app"
+               BlueprintName = "focus-lock"
+               ReferencedContainer = "container:focus-lock.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES"
+      queueDebuggingEnableBacktraceRecording = "Yes">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71209C202F1429F3008313C6"
+            BuildableName = "focus-lock.app"
+            BlueprintName = "focus-lock"
+            ReferencedContainer = "container:focus-lock.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "71209C202F1429F3008313C6"
+            BuildableName = "focus-lock.app"
+            BlueprintName = "focus-lock"
+            ReferencedContainer = "container:focus-lock.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/focus-lock/focus-lock/ScreenTimeShieldManager.swift
+++ b/focus-lock/focus-lock/ScreenTimeShieldManager.swift
@@ -1,0 +1,78 @@
+//
+//  ScreenTimeShieldManager.swift
+//  focus-lock
+//
+//  Created by Suraj Modur on 5/8/26.
+//
+
+import Foundation
+import ManagedSettings
+import FamilyControls
+
+final class ScreenTimeShieldManager {
+    static let shared = ScreenTimeShieldManager()
+
+    private let store = ManagedSettingsStore()
+
+    // Checks whether the current time falls inside a rule's start/end time.
+    // This compares only hour/minute, not the full date, because your rules repeat daily.
+    private func isRuleActiveRightNow(_ rule: Rule, now: Date = Date()) -> Bool {
+        let calendar = Calendar.current
+
+        let nowComponents = calendar.dateComponents([.hour, .minute], from: now)
+        let startComponents = calendar.dateComponents([.hour, .minute], from: rule.startTime)
+        let endComponents = calendar.dateComponents([.hour, .minute], from: rule.endTime)
+
+        let nowMinutes = (nowComponents.hour ?? 0) * 60 + (nowComponents.minute ?? 0)
+        let startMinutes = (startComponents.hour ?? 0) * 60 + (startComponents.minute ?? 0)
+        let endMinutes = (endComponents.hour ?? 0) * 60 + (endComponents.minute ?? 0)
+
+        // Normal same-day schedule, like 9:00 AM to 5:00 PM.
+        if startMinutes < endMinutes {
+            return nowMinutes >= startMinutes && nowMinutes < endMinutes
+        }
+
+        // Overnight schedule, like 9:00 PM to 12:00 AM or 10:00 PM to 6:00 AM.
+        // In this case, the active window crosses midnight.
+        if startMinutes > endMinutes {
+            return nowMinutes >= startMinutes || nowMinutes < endMinutes
+        }
+
+        // If start and end are the same, treat it as inactive for now.
+        // Later you could decide this means "blocked all day" if you want.
+        return false
+    }
+
+    // Rebuilds the shield list from rules that are enabled and active right now.
+    // Apps outside their scheduled time are not shielded.
+    //
+    // Important limitation:
+    // This method only checks the time at the moment it is called.
+    // Example: if you create a 9:00 AM - 10:00 AM rule at 8:30 AM,
+    // this method will correctly decide not to block yet. But the block will not
+    // automatically turn on at 9:00 AM unless something calls syncShields again.
+    // Later, DeviceActivityMonitor should handle that automatic start/end behavior.
+    func syncShields(for rules: [Rule]) {
+        let activeApplicationTokens = rules
+            .filter { rule in
+                rule.isEnabled && isRuleActiveRightNow(rule)
+            }
+            .reduce(into: Set<ApplicationToken>()) { selectedApps, rule in
+                selectedApps.formUnion(rule.activitySelection.applicationTokens)
+            }
+
+        // If no rules are active right now, remove all shields.
+        store.shield.applications = activeApplicationTokens.isEmpty ? nil : activeApplicationTokens
+    }
+
+    // Applies shields based on all rules instead of blindly shielding one saved rule.
+    // Use this after creating, deleting, or toggling a rule.
+    func refreshShields(for rules: [Rule]) {
+        syncShields(for: rules)
+    }
+
+    // Removes all app shields managed by this store.
+    func clearShields() {
+        store.shield.applications = nil
+    }
+}

--- a/focus-lock/focus-lock/State/AppState.swift
+++ b/focus-lock/focus-lock/State/AppState.swift
@@ -37,7 +37,25 @@ final class AppState: ObservableObject {
             activitySelection: activitySelection
         )
         rules.append(newRule)
+        // Temporarily shields the selected apps as soon as the rule is saved.
+        ScreenTimeShieldManager.shared.syncShields(for: rules)
+
+
         // Note: saveRules() is called automatically because of 'didSet' on the 'rules' variable.
+    }
+    
+    func toggleRule(id: UUID) {
+        guard let index = rules.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        // Flips the rule between enabled and disabled.
+        // The rules array saves automatically because of didSet.
+        rules[index].isEnabled.toggle()
+
+        // Rebuilds the active shields after the rule changes.
+        // If this rule was the only one blocking Instagram, disabling it removes the block.
+        ScreenTimeShieldManager.shared.syncShields(for: rules)
     }
     
     // Sets initial state of rules
@@ -91,6 +109,10 @@ final class AppState: ObservableObject {
         rules.removeAll(){
             $0.id == id
         }
+
+        // Re-apply shields using only the rules that still exist.
+        // If the deleted rule was the last active rule, this removes the block.
+        ScreenTimeShieldManager.shared.syncShields(for: rules)
     }
     
     
@@ -129,4 +151,3 @@ final class AppState: ObservableObject {
     }
     
 }
-

--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -52,8 +52,10 @@ struct RulesView: View {
                                     .foregroundStyle(rule.isEnabled ? .green : .red)
                                     .font(.title2)
                                     .onTapGesture {
-                                        rule.isEnabled.toggle()
+                                        // Toggle through AppState so the actual Screen Time shield updates too.
+                                        appState.toggleRule(id: rule.id)
                                     }
+
                                 
                                 Button(action:{
                                     


### PR DESCRIPTION
```markdown
## Focus Lock Screen Time Blocking Update

This PR adds the first working version of app blocking using Apple’s Screen Time APIs.

The app can now:

- Save rules with selected apps, start/end times, and enabled state
- Check whether a rule should be active based on the current time
- Apply iOS Screen Time shields to selected apps
- Remove shields when rules are deleted
- Remove/reapply shields when rules are disabled or enabled
- Show a custom blocked screen through a Shield Configuration Extension

## How The Blocking Flow Works

```text
User creates a rule
→ AppState saves the rule
→ ScreenTimeShieldManager checks if the rule is enabled and active right now
→ Active rule app tokens are applied to ManagedSettingsStore
→ User opens a shielded app
→ iOS shows the Shield Configuration blocked screen
```

## Main Files Changed

### `ScreenTimeShieldManager.swift`

Adds the app-side logic for applying and removing Screen Time shields.

The manager owns a `ManagedSettingsStore`:

```swift
private let store = ManagedSettingsStore()
```

This is the Apple API object used to apply restrictions. The actual shield is applied here:

```swift
store.shield.applications = activeApplicationTokens.isEmpty ? nil : activeApplicationTokens
```

If `activeApplicationTokens` contains selected apps, iOS shields those apps. If it is empty, the shield is removed.

### Time-Based Rule Checking

`ScreenTimeShieldManager` includes:

```swift
private func isRuleActiveRightNow(_ rule: Rule, now: Date = Date()) -> Bool
```

This helper checks whether the current time falls inside the rule’s configured start/end time.

It supports:

- Same-day schedules, like `9:00 AM - 5:00 PM`
- Overnight schedules, like `9:00 PM - 12:00 AM` or `10:00 PM - 6:00 AM`

The rule is only considered active when the current time is inside that window.

### Shield Syncing

`syncShields(for:)` rebuilds the full list of apps that should be blocked:

```swift
func syncShields(for rules: [Rule]) {
    let activeApplicationTokens = rules
        .filter { rule in
            rule.isEnabled && isRuleActiveRightNow(rule)
        }
        .reduce(into: Set<ApplicationToken>()) { selectedApps, rule in
            selectedApps.formUnion(rule.activitySelection.applicationTokens)
        }

    store.shield.applications = activeApplicationTokens.isEmpty ? nil : activeApplicationTokens
}
```

This method:

1. Looks through all rules.
2. Keeps only rules that are enabled and active right now.
3. Collects all selected app tokens from those rules.
4. Applies the shield if apps should be blocked.
5. Removes the shield if no rules are currently active.

Important limitation:

`syncShields(for:)` only checks the time when it is called.

For example, if a user creates a rule for `9:00 AM - 10:00 AM` at `8:30 AM`, the app correctly decides not to block yet. However, it will not automatically start blocking at `9:00 AM` unless something calls `syncShields(for:)` again.

The future fix is to add a `DeviceActivityMonitor` extension so iOS can automatically start and stop shields at rule boundaries.

## `AppState.swift`

`AppState` now calls `ScreenTimeShieldManager.shared.syncShields(for: rules)` after rule changes.

### Add Rule

After a rule is created and saved, shields are recalculated:

```swift
rules.append(newRule)
ScreenTimeShieldManager.shared.syncShields(for: rules)
```

This means the new rule only applies a block immediately if it is enabled and currently inside its scheduled time.

### Delete Rule

After a rule is deleted, shields are recalculated:

```swift
func deleteRule(id: UUID) {
    rules.removeAll() {
        $0.id == id
    }

    ScreenTimeShieldManager.shared.syncShields(for: rules)
}
```

This ensures that deleting a rule removes its block.

If another enabled and active rule still blocks the same app, the app stays blocked.

### Toggle Rule

Rules can now be enabled or disabled through `AppState`:

```swift
func toggleRule(id: UUID) {
    guard let index = rules.firstIndex(where: { $0.id == id }) else {
        return
    }

    rules[index].isEnabled.toggle()

    ScreenTimeShieldManager.shared.syncShields(for: rules)
}
```

This keeps the UI state and actual Screen Time shield state in sync.

Disabling a rule removes its block if no other active rule still blocks the same app. Re-enabling the rule reapplies the block if the rule is active at the current time.

## `RulesView.swift`

The enabled/disabled icon now calls into `AppState` instead of directly toggling the rule value:

```swift
appState.toggleRule(id: rule.id)
```

This is important because toggling the value directly would only update the UI/data. Calling `AppState.toggleRule` also updates the actual iOS shield.

Rule deletion continues to go through:

```swift
appState.deleteRule(id: rule.id)
```

This ensures the shield state is recalculated after deletion.

## Shield Configuration Extension

This PR also adds/customizes a Shield Configuration Extension.

File:

```text
FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
```

This controls the blocked screen iOS shows when the user opens a shielded app.

The key method is:

```swift
override func configuration(shielding application: Application) -> ShieldConfiguration
```

This method runs when iOS needs to display the blocked screen for a shielded app.

It currently logs:

```swift
print("User attempted to open a shielded app")
```

This confirms that the user tried to open a blocked app and that iOS requested the shield UI.

The returned shield configuration customizes the blocked screen:

```swift
return ShieldConfiguration(
    title: .init(
        text: "App is blocked",
        color: .label
    ),
    subtitle: .init(
        text: "Focus Lock is keeping you away from this app.",
        color: .secondaryLabel
    ),
    primaryButtonLabel: .init(
        text: "Pay $5 to unlock",
        color: .white
    ),
    primaryButtonBackgroundColor: .systemBlue
)
```

Note: this is not a normal SwiftUI view. iOS does not allow a fully custom SwiftUI screen to appear over another app. Instead, the Shield Configuration Extension customizes Apple’s system shield screen.

## Current Behavior

### Rule Created During Active Time

```text
Current time: 9:30 AM
Rule time: 9:00 AM - 10:00 AM
Selected app: Instagram
Result: Instagram is blocked
```

### Rule Created Before Active Time

```text
Current time: 8:30 AM
Rule time: 9:00 AM - 10:00 AM
Selected app: Instagram
Result: Instagram is not blocked yet
```

Limitation: the app will not automatically start blocking at `9:00 AM` until `syncShields(for:)` is called again.

### Rule Disabled

```text
Active Instagram rule is disabled
→ syncShields(for:) runs
→ disabled rule is ignored
→ Instagram becomes usable again
```

### Rule Deleted

```text
Active Instagram rule is deleted
→ syncShields(for:) runs
→ deleted rule is removed from the shield calculation
→ Instagram becomes usable again unless another active rule still blocks it
```

## Future Work

The next major improvement is automatic scheduling with `DeviceActivityMonitor`.

That will allow iOS to automatically call extension code at a rule’s start and end times:

```text
9:00 AM rule starts
→ iOS applies shield automatically

10:00 AM rule ends
→ iOS removes shield automatically
```

This will remove the current need to manually call `syncShields(for:)` after app events.
```