### PR TITLE
Implemented Editing Rule functionality

### DIFF
--- a/focus-lock/focus-lock.xcodeproj/xcshareddata/xcschemes/focus-lock.xcscheme
+++ b/focus-lock/focus-lock.xcodeproj/xcshareddata/xcschemes/focus-lock.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "2640"
-   version = "1.7">
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/focus-lock/focus-lock/State/AppState.swift
+++ b/focus-lock/focus-lock/State/AppState.swift
@@ -98,6 +98,33 @@ final class AppState: ObservableObject {
 
         // didSet re-applies schedules and shields using only the rules that still exist.
     }
+    
+    func editRule(id: UUID,
+                  title: String,
+                  start: Date,
+                  end: Date,
+                  activitySelection: FamilyActivitySelection
+              ){
+        // Finds the position of the rule in the rules array whose id matches the id passed into this function.
+        guard let index = rules.firstIndex(where: {$0.id == id}) else{
+            return
+        }
+        
+        // Replace the old title with the new title from the edit form.
+            rules[index].title = title
+
+            // Replace the old start time with the new start time from the edit form.
+            rules[index].startTime = start
+
+            // Replace the old end time with the new end time from the edit form.
+            rules[index].endTime = end
+
+            // Replace the old Screen Time app/category selection with the new selection from the edit form.
+            rules[index].activitySelection = activitySelection
+
+            // Because rules is @Published and has didSet, changing this rule automatically saves and syncs it.
+        
+    }
 
     private func persistAndSyncRules() {
         // 1. Save the latest rules to shared storage.

--- a/focus-lock/focus-lock/Views/EditRuleView.swift
+++ b/focus-lock/focus-lock/Views/EditRuleView.swift
@@ -1,0 +1,156 @@
+//
+//  EditRuleView.swift
+//  focus-lock
+//
+
+// Imports SwiftUI so this file can build screens, forms, buttons, and navigation.
+import SwiftUI
+
+// Imports FamilyControls so this file can use FamilyActivitySelection and familyActivityPicker.
+import FamilyControls
+
+// Defines a SwiftUI screen used to edit one existing rule.
+struct EditRuleView: View {
+    // Gets SwiftUI's built-in dismiss action so this sheet can close itself.
+    @Environment(\.dismiss) var dismiss
+
+    // Gets the shared AppState so this screen can save edited rule data.
+    @EnvironmentObject var appState: AppState
+
+    // Stores the original rule passed in from RulesView.
+    let rule: Rule
+
+    // Stores the editable rule name while the user types.
+    @State private var ruleName: String
+
+    // Stores the editable start time while the user changes it.
+    @State private var startTime: Date
+
+    // Stores the editable end time while the user changes it.
+    @State private var endTime: Date
+
+    // Stores the editable app/category selection.
+    @State private var activitySelection: FamilyActivitySelection
+
+    // Tracks whether Apple's Screen Time picker should be visible.
+    @State private var showAppPicker = false
+
+    // Runs when this edit screen is created with a specific rule.
+    init(rule: Rule) {
+        // Saves the original rule so we can use its id later when saving.
+        self.rule = rule
+
+        // Fills the text field with the rule's current title.
+        _ruleName = State(initialValue: rule.title)
+
+        // Fills the start picker with the rule's current start time.
+        _startTime = State(initialValue: rule.startTime)
+
+        // Fills the end picker with the rule's current end time.
+        _endTime = State(initialValue: rule.endTime)
+
+        // Fills the app picker with the rule's current selected apps.
+        _activitySelection = State(initialValue: rule.activitySelection)
+    }
+
+    // Describes the UI that appears inside the edit sheet.
+    var body: some View {
+        // Adds navigation styling so the sheet can have a title and toolbar buttons.
+        NavigationStack {
+            // Creates an iOS-style form layout for the editable fields.
+            Form {
+                // Groups the rule name field under a Rule Details heading.
+                Section("Rule Details") {
+                    // Lets the user change the rule name.
+                    TextField("Rule Name", text: $ruleName)
+                }
+
+                // Groups the time pickers under a Schedule heading.
+                Section("Schedule") {
+                    // Lets the user change the start time.
+                    DatePicker("Start Time", selection: $startTime, displayedComponents: .hourAndMinute)
+
+                    // Lets the user change the end time.
+                    DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
+                }
+
+                // Groups the selected app controls under an Apps heading.
+                Section("Apps") {
+                    // Creates a tappable row for opening the app picker.
+                    Button {
+                        // Changes state so Apple's Screen Time picker opens.
+                        showAppPicker = true
+                    } label: {
+                        // Places the row title and selected count horizontally.
+                        HStack {
+                            // Shows the label for the app picker row.
+                            Text("Select Apps")
+
+                            // Pushes the selected count to the right side of the row.
+                            Spacer()
+
+                            // Shows how many apps are currently selected.
+                            Text("\(activitySelection.applicationTokens.count) selected")
+                                // Makes the selected count use secondary text styling.
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            }
+
+            // Shows Edit Rule as the sheet title.
+            .navigationTitle(Text("Edit Rule"))
+
+            // Adds navigation bar buttons to the sheet.
+            .toolbar {
+                // Places this item where Cancel actions normally appear.
+                ToolbarItem(placement: .cancellationAction) {
+                    // Creates a Cancel button.
+                    Button("Cancel") {
+                        // Closes the edit sheet without saving changes.
+                        dismiss()
+                    }
+                }
+
+                // Places this item where Save actions normally appear.
+                ToolbarItem(placement: .confirmationAction) {
+                    // Creates a Save button.
+                    Button("Save") {
+                        // Calls AppState to update the existing rule in the rules array.
+                        appState.editRule(
+                            // Sends the original rule id so AppState knows which rule to update.
+                            id: rule.id,
+
+                            // Sends the edited rule name.
+                            title: ruleName,
+
+                            // Sends the edited start time.
+                            start: startTime,
+
+                            // Sends the edited end time.
+                            end: endTime,
+
+                            // Sends the edited app/category selection.
+                            activitySelection: activitySelection
+                        )
+
+                        // Closes the edit sheet after saving.
+                        dismiss()
+                    }
+
+                    // Prevents saving when required fields are missing.
+                    .disabled(ruleName.isEmpty || activitySelection.applicationTokens.isEmpty)
+                }
+            }
+
+            // Attaches Apple's Screen Time picker to this edit screen.
+            .familyActivityPicker(
+                // Opens the picker when showAppPicker becomes true.
+                isPresented: $showAppPicker,
+
+                // Stores the user's picker choices in activitySelection.
+                selection: $activitySelection
+            )
+        }
+    }
+}

--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -13,7 +13,10 @@ struct RulesView: View {
     // New State to track if the sheet(rule add modal) is open
     @State private var showCreateSheet = false
     
+    @State private var ruleBeingEdited: Rule?
+    
     @State private var goToBlocked = false
+    
     
     @EnvironmentObject var appState: AppState
     
@@ -35,6 +38,9 @@ struct RulesView: View {
             .sheet(isPresented: $showCreateSheet){
                 CreateRuleView()
             }
+            .sheet(item: $ruleBeingEdited){ rule in
+                EditRuleView(rule:rule)
+            }
             
             
             ScrollView(.vertical, showsIndicators: false) {
@@ -55,7 +61,18 @@ struct RulesView: View {
                                         // Toggle through AppState so the actual Screen Time shield updates too.
                                         appState.toggleRule(id: rule.id)
                                     }
-
+                                
+                                //Editing Rule Button
+                                Button(action: {
+                                    //Updated state var with rule that is currently being edited and goes back to .sheet to call EditRuleView
+                                    ruleBeingEdited = rule
+                                }) {
+                                    Image(systemName: "pencil")
+                                        .foregroundStyle(.blue)
+                                        .font(.title2)
+                                }
+                                .buttonStyle(BorderlessButtonStyle())
+                                
                                 
                                 Button(action:{
                                     


### PR DESCRIPTION
```markdown
## Summary

This PR adds rule editing support to the Rules screen.

Users can now tap a pencil icon on an existing rule, open an edit sheet, update the rule details, and save those changes back into app state.

## What Changed

### Added edit button to each rule row

A new pencil icon button was added between the enabled/disabled toggle icon and the trash button in `RulesView`.

When tapped, the button sets:

```swift
ruleBeingEdited = rule
```

This stores the selected rule in local SwiftUI state and triggers the edit sheet.

### Added edit sheet state

`RulesView` now includes:

```swift
@State private var ruleBeingEdited: Rule?
```

This tracks which rule is currently being edited.

The edit sheet is presented with:

```swift
.sheet(item: $ruleBeingEdited) { rule in
    EditRuleView(rule: rule)
}
```

When `ruleBeingEdited` is `nil`, no edit sheet is shown. When it contains a `Rule`, SwiftUI opens `EditRuleView` and passes that selected rule into it.

### Added `EditRuleView`

This PR adds a new `EditRuleView` screen.

`EditRuleView` is pre-filled with the selected rule’s existing values:

- Rule title
- Start time
- End time
- Selected Screen Time apps/categories

The UI uses the same general form structure as rule creation:

- `TextField` for the rule name
- `DatePicker` controls for start and end time
- `familyActivityPicker` for selecting apps
- Cancel and Save toolbar actions

### Added save behavior for edited rules

`EditRuleView` calls:

```swift
appState.editRule(
    id: rule.id,
    title: ruleName,
    start: startTime,
    end: endTime,
    activitySelection: activitySelection
)
```

This updates the existing rule instead of creating a new one.

### Added `editRule` to `AppState`

`AppState` now includes an `editRule` function that:

1. Finds the rule by `id`
2. Updates the rule title
3. Updates the start time
4. Updates the end time
5. Updates the selected app/category activity selection

Because `rules` is `@Published` and has a `didSet`, editing a rule automatically reuses the existing persistence and sync flow:

- Saves rules to shared storage
- Syncs Device Activity schedules
- Refreshes Screen Time shields

## Files Changed

### `focus-lock/Views/RulesView.swift`

- Added `ruleBeingEdited` state
- Added `.sheet(item:)` for presenting `EditRuleView`
- Added pencil edit button to each rule row
- Pencil button now selects the tapped rule for editing

### `focus-lock/Views/EditRuleView.swift`

- Added a new edit form view
- Preloads the selected rule’s existing values into local `@State`
- Allows editing title, schedule, and selected apps
- Saves changes through `appState.editRule(...)`
- Uses `dismiss()` for Cancel and after Save

### `focus-lock/State/AppState.swift`

- Added `editRule(...)`
- Updates the existing rule in the `rules` array by matching `UUID`
- Relies on the existing `rules.didSet` behavior to persist and sync changes

## User Flow

1. User opens the Rules screen.
2. User taps the pencil icon on a rule.
3. `RulesView` stores that rule in `ruleBeingEdited`.
4. SwiftUI presents `EditRuleView`.
5. `EditRuleView` loads the selected rule’s current values.
6. User edits the rule name, times, or selected apps.
7. User taps Save.
8. `AppState.editRule(...)` updates the existing rule.
9. The sheet closes.
10. Existing save/schedule/shield sync logic runs automatically.

## Validation Rules

The Save button is disabled when:

- The rule name is empty
- No apps are selected

This matches the create rule behavior and prevents incomplete rules from being saved.

## Notes

- The edit button uses SF Symbol `pencil`.
- The edit sheet uses SwiftUI state instead of navigation because editing is a temporary modal workflow.
- `EditRuleView` currently duplicates some UI structure from `CreateRuleView`. A future cleanup could extract the shared form fields into a reusable `RuleFormView`.
- Build verification was not run in this environment because `xcodebuild` requires full Xcode, but the active developer directory is currently set to Command Line Tools.
```