### PR TITLE
Included Device Alert Popup for <15 min rules

### DIFF
--- a/focus-lock/Shared/FocusLockSchedule.swift
+++ b/focus-lock/Shared/FocusLockSchedule.swift
@@ -22,6 +22,9 @@ import ManagedSettings
 // The app and the DeviceActivity extension should agree on schedule behavior.
 // So the "is this rule active right now?" logic lives here once instead of being copied.
 enum FocusLockSchedule {
+    // DeviceActivity can reject very short schedules with an intervalTooShort error.
+    // Keeping the minimum in one shared constant makes the UI validation and
+    // schedule registration use the same rule.
     static let minimumMonitorDurationMinutes = 15
 
     // Decides whether a rule is worth registering with DeviceActivity.

--- a/focus-lock/focus-lock/Views/CreateRuleView.swift
+++ b/focus-lock/focus-lock/Views/CreateRuleView.swift
@@ -18,6 +18,9 @@ struct CreateRuleView: View {
 
     @State private var activitySelection = FamilyActivitySelection()
     @State private var showAppPicker = false
+    // Controls the popup shown when the selected schedule is too short for DeviceActivity.
+    @State private var showDurationAlert = false
+
 
     var body: some View {
         NavigationStack {
@@ -55,6 +58,23 @@ struct CreateRuleView: View {
 
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
+                        // Create a temporary rule so we can reuse the same duration helper
+                        // that the schedule manager uses before saving anything.
+                        let draftRule = Rule(
+                                title: ruleName,
+                                isEnabled: true,
+                                startTime: startTime,
+                                endTime: endTime,
+                                activitySelection: activitySelection
+                            )
+                        
+                        // DeviceActivity will not monitor intervals shorter than our shared
+                        // minimum, so show an alert instead of saving a rule iOS will skip.
+                        if FocusLockSchedule.durationMinutes(for: draftRule) < FocusLockSchedule.minimumMonitorDurationMinutes{
+                            showDurationAlert = true
+                            return
+                        }
+                        
                         appState.addRule(
                             title: ruleName,
                             start: startTime,
@@ -66,6 +86,12 @@ struct CreateRuleView: View {
                     }
                     .disabled(ruleName.isEmpty || activitySelection.applicationTokens.isEmpty)
                 }
+            }
+            // Explains why Save did not work when the schedule is under the minimum duration.
+            .alert("Schedule Too Short", isPresented: $showDurationAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Focus Lock rules must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes long.")
             }
             .familyActivityPicker(
                 isPresented: $showAppPicker,

--- a/focus-lock/focus-lock/Views/EditRuleView.swift
+++ b/focus-lock/focus-lock/Views/EditRuleView.swift
@@ -34,6 +34,10 @@ struct EditRuleView: View {
 
     // Tracks whether Apple's Screen Time picker should be visible.
     @State private var showAppPicker = false
+    
+    // Controls the popup shown when the edited schedule is too short for DeviceActivity.
+    @State private var showDurationAlert = false
+
 
     // Runs when this edit screen is created with a specific rule.
     init(rule: Rule) {
@@ -114,35 +118,48 @@ struct EditRuleView: View {
 
                 // Places this item where Save actions normally appear.
                 ToolbarItem(placement: .confirmationAction) {
-                    // Creates a Save button.
                     Button("Save") {
-                        // Calls AppState to update the existing rule in the rules array.
-                        appState.editRule(
-                            // Sends the original rule id so AppState knows which rule to update.
+                        // Create a temporary version of the edited rule so we can check the
+                        // new start/end time before changing the saved rule.
+                        let draftRule = Rule(
                             id: rule.id,
-
-                            // Sends the edited rule name.
                             title: ruleName,
-
-                            // Sends the edited start time.
-                            start: startTime,
-
-                            // Sends the edited end time.
-                            end: endTime,
-
-                            // Sends the edited app/category selection.
+                            isEnabled: rule.isEnabled,
+                            createdAt: rule.createdAt,
+                            startTime: startTime,
+                            endTime: endTime,
                             activitySelection: activitySelection
                         )
 
-                        // Closes the edit sheet after saving.
+                        // DeviceActivity will not monitor intervals shorter than our shared
+                        // minimum, so keep the original rule unchanged and explain the problem.
+                        if FocusLockSchedule.durationMinutes(for: draftRule) < FocusLockSchedule.minimumMonitorDurationMinutes {
+                            showDurationAlert = true
+                            return
+                        }
+
+                        appState.editRule(
+                            id: rule.id,
+                            title: ruleName,
+                            start: startTime,
+                            end: endTime,
+                            activitySelection: activitySelection
+                        )
+
                         dismiss()
                     }
+
 
                     // Prevents saving when required fields are missing.
                     .disabled(ruleName.isEmpty || activitySelection.applicationTokens.isEmpty)
                 }
             }
-
+            // Explains why Save did not work when the schedule is under the minimum duration.
+            .alert("Schedule Too Short", isPresented: $showDurationAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Focus Lock rules must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes long.")
+            }
             // Attaches Apple's Screen Time picker to this edit screen.
             .familyActivityPicker(
                 // Opens the picker when showAppPicker becomes true.


### PR DESCRIPTION
```markdown
## Summary

Adds user-facing validation for Focus Lock rule schedules shorter than the DeviceActivity minimum duration.

Rules with a start/end time difference under 15 minutes cannot be monitored reliably by `DeviceActivityCenter`, so the create and edit flows now show an alert instead of saving an invalid schedule.

## Changes

- Added a “Schedule Too Short” alert to the rule creation flow.
- Added the same validation alert to the rule editing flow.
- Prevents saving when the selected schedule duration is less than `FocusLockSchedule.minimumMonitorDurationMinutes`.
- Keeps the user on the create/edit sheet so they can adjust the times.
- Reuses the existing schedule duration/minimum constants so UI validation matches DeviceActivity registration behavior.

## Why

The schedule registration logic already skips rules shorter than the minimum monitor duration. Without UI validation, users could create or edit rules that appear valid in the app but never get registered with iOS for monitoring.

This makes the failure visible and actionable before the rule is saved.

## Acceptance Criteria

- Creating a rule with a duration under 15 minutes shows an error popup.
- Editing a rule to a duration under 15 minutes shows an error popup.
- Invalid short-duration rules are not saved.
- Valid rules of 15 minutes or longer still save normally.
- Validation uses the same minimum duration value used by schedule registration.

## Out of Scope

- No changes to DeviceActivity callback behavior.
- No changes to shield application logic.
- No changes to schedule registration beyond preventing invalid schedules from being saved.
```