### PR TITLE
[codex] Fix App Group runtime config

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,332 @@
+# Focus Lock Project Context for Future Codex Sessions
+
+This document is the durable handoff for future Codex sessions and contributors. Update it as the project changes.
+
+## Project Goal
+
+Focus Lock is an iOS app that uses Apple's Screen Time APIs to let a user create rules that block selected apps during scheduled windows.
+
+The MVP direction is:
+
+- request Screen Time / FamilyControls authorization
+- let the user select apps with Apple's picker
+- save rules with selected app tokens and daily time windows
+- block selected apps during active rules
+- keep enforcement working when the main app is closed
+
+## Current Branch Context
+
+As of PR #35, the app has:
+
+- app selection through `FamilyActivitySelection`
+- custom shield UI through `FocusLockShieldConfiguration`
+- closed-app schedule enforcement through `FocusLockDeviceActivityMonitor`
+- shared rule storage using an App Group
+- a long-form learning doc at `docs/device-activity-enforcement-deep-dive.md`
+
+The branch that introduced the DeviceActivity enforcement context was:
+
+```text
+codex/device-activity-enforcement
+```
+
+## Important Apple Frameworks
+
+Use this mental model:
+
+```text
+FamilyControls = permission and app selection
+ManagedSettings = app shielding / blocking
+ManagedSettingsUI = custom blocked-screen UI
+DeviceActivity = scheduled callbacks while the app is closed
+App Groups = shared storage between app and extension
+```
+
+## Target Structure
+
+The Xcode project has three targets:
+
+```text
+focus-lock
+  Main SwiftUI app.
+  Creates rules, saves rules, registers schedules, and syncs shields immediately.
+
+FocusLockShieldConfiguration
+  ManagedSettingsUI shield configuration extension.
+  Customizes the blocked screen shown by iOS.
+
+FocusLockDeviceActivityMonitor
+  DeviceActivity monitor extension.
+  Woken by iOS at schedule start/end.
+  Reads saved rules from App Group storage and applies/clears shields.
+```
+
+The shared Swift files live in:
+
+```text
+focus-lock/Shared/
+```
+
+Those files are compiled into both the main app and `FocusLockDeviceActivityMonitor`.
+
+## Key Runtime Flow
+
+When a rule is created/toggled/deleted:
+
+```text
+AppState changes rules
+  -> FocusLockRuleStore saves rules.json into App Group storage
+  -> DeviceActivityScheduleManager registers schedules with DeviceActivityCenter
+  -> ScreenTimeShieldManager syncs shields immediately while app is open
+```
+
+When the app is closed and a schedule boundary happens:
+
+```text
+iOS wakes FocusLockDeviceActivityMonitor
+  -> intervalDidStart or intervalDidEnd runs
+  -> extension loads rules.json from App Group storage
+  -> FocusLockSchedule computes active app tokens
+  -> ManagedSettingsStore applies or clears shields
+```
+
+## Important Files
+
+```text
+focus-lock/focus-lock/State/AppState.swift
+  Owns the in-memory rules array.
+  Saves rules and triggers schedule/shield syncs.
+
+focus-lock/focus-lock/DeviceActivityScheduleManager.swift
+  Registers rule schedules with DeviceActivityCenter.
+
+focus-lock/focus-lock/ScreenTimeShieldManager.swift
+  Applies immediate shields while the app is open.
+
+focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+  Extension callback entrypoint for closed-app enforcement.
+
+focus-lock/Shared/Rule.swift
+  Shared Rule model.
+
+focus-lock/Shared/FocusLockRuleStore.swift
+  Saves and loads rules.json from App Group storage.
+
+focus-lock/Shared/FocusLockSchedule.swift
+  Shared schedule math and active-token calculation.
+
+focus-lock/Shared/FocusLockConfiguration.swift
+  Determines the App Group identifier.
+
+focus-lock/Shared/FocusLockDiagnostics.swift
+  Temporary diagnostics helper, off by default.
+```
+
+## Signing and Local Config
+
+Both developers use individual Apple Developer accounts. Do not commit personal signing values.
+
+Each developer should have an ignored local file:
+
+```text
+focus-lock/Config/Local.xcconfig
+```
+
+Shabarish local config:
+
+```xcconfig
+DEVELOPMENT_TEAM = 6326888VVQ
+APP_BUNDLE_ID = com.focuslock.focuslockapp
+APP_GROUP_IDENTIFIER = group.com.focuslock.focuslockapp
+```
+
+Suraj local config:
+
+```xcconfig
+DEVELOPMENT_TEAM = TGK2CZ6QA4
+APP_BUNDLE_ID = com.focuslock.focuslock-app
+APP_GROUP_IDENTIFIER = group.com.focuslock.focuslock-app
+```
+
+Committed defaults live in:
+
+```text
+focus-lock/Config/Shared.xcconfig
+focus-lock/Config/Local.example.xcconfig
+```
+
+The entitlements use:
+
+```xml
+$(APP_GROUP_IDENTIFIER)
+```
+
+## App Group Requirements
+
+App Groups must be enabled for:
+
+```text
+focus-lock
+FocusLockDeviceActivityMonitor
+```
+
+`FocusLockShieldConfiguration` does not currently need App Groups because it only customizes the blocked screen UI and does not read saved rules.
+
+Common App Group failure:
+
+```text
+container_create_or_lookup_app_group_path_by_app_group_identifier: client is not entitled
+```
+
+This means the running app/extension is not signed for the App Group it is trying to use.
+
+## DeviceActivity Schedule Gotcha
+
+Very short schedules fail.
+
+During testing, a 1-2 minute rule failed with:
+
+```text
+MonitoringError.intervalTooShort
+```
+
+The current code uses:
+
+```swift
+FocusLockSchedule.minimumMonitorDurationMinutes = 15
+```
+
+Rules shorter than that are not registered with DeviceActivity. UI validation is not implemented yet.
+
+Follow-up issue:
+
+```text
+#33 Add UI validation for DeviceActivity minimum rule duration
+```
+
+## Info.plist/App Group Gotcha
+
+Runtime App Group lookup comes from the custom Info.plist key:
+
+```text
+FocusLockAppGroupIdentifier
+```
+
+The same `APP_GROUP_IDENTIFIER` build setting should feed both:
+
+```text
+Entitlements -> signing/capability access
+Info.plist   -> Swift runtime lookup
+```
+
+The main app plist is `focus-lock/Config/focus-lock-Info.plist`. The DeviceActivity monitor extension plist is `focus-lock/FocusLockDeviceActivityMonitor/Info.plist`.
+
+If those values diverge, App Group storage can fail with `client is not entitled`.
+
+If `FocusLockAppGroupIdentifier` is missing, treat it as a project configuration bug. The app should not quietly derive an App Group from the bundle ID because that can hide signing/runtime mismatches.
+
+## Diagnostics
+
+Diagnostics live in:
+
+```text
+focus-lock/Shared/FocusLockDiagnostics.swift
+```
+
+They are off by default:
+
+```swift
+private static let isEnabled = false
+```
+
+Temporarily flip to `true` when debugging:
+
+- App Group storage
+- DeviceActivity schedule registration
+- monitor extension callbacks
+
+Do not leave diagnostics enabled for normal PRs unless the PR is specifically about debugging.
+
+## Testing Guidance
+
+Use a real iPhone for Screen Time behavior. The simulator is not reliable for FamilyControls, ManagedSettings, App Groups, or DeviceActivity enforcement.
+
+Recommended closed-app enforcement test:
+
+1. Delete the app from the phone if signing/capabilities changed.
+2. Build/run from Xcode on the phone.
+3. Create a rule starting a few minutes in the future.
+4. Make the rule duration at least 15 minutes.
+5. Save the rule.
+6. Leave Focus Lock normally. Do not force quit.
+7. Open a selected blocked app after the start time.
+8. Confirm it is blocked.
+9. Confirm it unblocks after the end time.
+
+If diagnostics are enabled, look for:
+
+```text
+ScheduleManager successfully registered ...
+DeviceActivityMonitor intervalDidStart fired ...
+DeviceActivityMonitor applied shields.
+```
+
+## Git Hygiene
+
+Do not commit:
+
+```text
+.DS_Store
+xcuserdata/
+*.xcuserstate
+focus-lock/Config/Local.xcconfig
+```
+
+Be careful with:
+
+```text
+focus-lock/focus-lock.xcodeproj/project.pbxproj
+```
+
+This file can contain both real project structure changes and accidental local signing churn. Review it before committing.
+
+## Current Open Follow-ups
+
+```text
+#33 Add UI validation for DeviceActivity minimum rule duration
+```
+
+Likely future tickets:
+
+- reduce or clean up beginner-heavy comments after both developers understand the flow
+- decide whether diagnostics stay as a helper or move behind a debug build flag
+- improve schedule editing and deletion UX
+- add tests or lightweight debug UI for saved rules/schedules
+
+## Recommended PR Review Order
+
+For PR #35 and related work:
+
+1. Read `docs/device-activity-enforcement-deep-dive.md`.
+2. Review shared files in `focus-lock/Shared/`.
+3. Review `DeviceActivityScheduleManager.swift`.
+4. Review `DeviceActivityMonitorExtension.swift`.
+5. Review `project.pbxproj` last, focusing on target wiring and entitlements.
+
+## Working Style for Future Codex Sessions
+
+The user is learning iOS and Swift. Prefer:
+
+- explaining concepts slowly
+- keeping comments where they teach Apple-specific behavior
+- committing in small, understandable chunks
+- checking `project.pbxproj` carefully before committing
+- using real-device testing for Screen Time features
+- documenting partner setup steps in PR descriptions
+
+Avoid:
+
+- hiding signing changes in large commits
+- assuming simulator behavior proves Screen Time features
+- committing personal local config
+- force pushing unless intentionally amending a branch and using `--force-with-lease`

--- a/docs/device-activity-enforcement-deep-dive.md
+++ b/docs/device-activity-enforcement-deep-dive.md
@@ -173,6 +173,8 @@ The committed entitlements use:
 $(APP_GROUP_IDENTIFIER)
 ```
 
+The app also reads `FocusLockAppGroupIdentifier` from Info.plist at runtime. The main app plist lives at `focus-lock/Config/focus-lock-Info.plist`, and the monitor extension plist lives at `focus-lock/FocusLockDeviceActivityMonitor/Info.plist`. Xcode writes the same `APP_GROUP_IDENTIFIER` build setting into both, so signing and runtime storage lookup stay in sync.
+
 That keeps the committed project flexible for both individual Apple Developer accounts.
 
 ## 6. The Shared Rule Model
@@ -412,9 +414,9 @@ It also has:
 
 That tells iOS which Swift class to instantiate when the extension runs.
 
-### What we wanted from Info.plist
+### What Info.plist provides
 
-We tried to read this from Info.plist:
+The app and DeviceActivity monitor extension read this from Info.plist:
 
 ```text
 FocusLockAppGroupIdentifier
@@ -424,7 +426,7 @@ The idea was:
 
 ```text
 Xcode build settings know APP_GROUP_IDENTIFIER.
-Xcode writes APP_GROUP_IDENTIFIER into Info.plist.
+Xcode writes APP_GROUP_IDENTIFIER into the app and monitor extension Info.plists.
 Swift reads FocusLockAppGroupIdentifier from Info.plist.
 Swift uses that value to find the App Group container.
 ```
@@ -447,7 +449,7 @@ or:
 APP_GROUP_IDENTIFIER = group.com.focuslock.focuslock-app
 ```
 
-In theory, that is a nice design:
+That gives us one source of truth:
 
 ```text
 Local.xcconfig controls local identity.
@@ -455,31 +457,24 @@ Entitlements use the same value for signing.
 Info.plist exposes the same value to Swift at runtime.
 ```
 
-### What actually happened
+### Why this matters
 
-But runtime logs showed:
-
-```text
-(bundle identifier fallback)
-```
-
-That means the custom Info.plist key was not available at runtime.
-
-So Swift asked:
+App Group access has two sides:
 
 ```text
-Do you have FocusLockAppGroupIdentifier?
+Entitlements say what the signed binary is allowed to access.
+Runtime code says which App Group container the app asks FileManager to open.
 ```
 
-and the running app effectively answered:
+Those two strings must match exactly. If the app asks for a group that is not in its entitlements, iOS reports:
 
 ```text
-No.
+container_create_or_lookup_app_group_path_by_app_group_identifier: client is not entitled
 ```
 
-The app still needed an App Group string, so it used fallback logic.
+### What went wrong before
 
-At first, the fallback was hardcoded to Suraj's group:
+At first, the fallback path was hardcoded to Suraj's group:
 
 ```text
 group.com.focuslock.focuslock-app
@@ -491,80 +486,40 @@ That broke on Shabarish's device, which needed:
 group.com.focuslock.focuslockapp
 ```
 
-### What we did instead
-
-The current fallback derives from the running bundle ID:
+Then the fallback was improved to derive from the running bundle ID:
 
 ```text
 com.focuslock.focuslockapp
 -> group.com.focuslock.focuslockapp
 ```
 
-For the extension:
+That helped prove the feature worked on both local setups, but it still left the app with two possible configuration sources.
+
+### Current behavior
+
+The code now treats `FocusLockAppGroupIdentifier` as required. That means the runtime App Group lookup should follow this path:
 
 ```text
-com.focuslock.focuslockapp.FocusLockDeviceActivityMonitor
--> group.com.focuslock.focuslockapp
+APP_GROUP_IDENTIFIER in xcconfig
+-> FocusLockAppGroupIdentifier in Info.plist
+-> FocusLockConfiguration.appGroupIdentifier
+-> FileManager.default.containerURL(...)
 ```
 
-This works because our convention is:
+If the Info.plist key is missing, that is a project configuration bug to fix directly. The app should not quietly invent an App Group string from the bundle ID.
+
+For Shabarish, the expected local values are:
 
 ```text
-App Group = group.<main app bundle id>
+APP_BUNDLE_ID = com.focuslock.focuslockapp
+APP_GROUP_IDENTIFIER = group.com.focuslock.focuslockapp
 ```
 
-For the main app, the bundle ID is already the base app ID:
+For Suraj, the expected local values are:
 
 ```text
-com.focuslock.focuslockapp
-```
-
-For the extension, the bundle ID has a suffix:
-
-```text
-com.focuslock.focuslockapp.FocusLockDeviceActivityMonitor
-```
-
-So the fallback removes known extension suffixes before adding `group.`.
-
-### Why this is okay for now
-
-The fallback is safer than hardcoding one developer's value because it adapts to both local setups:
-
-```text
-Shabarish:
-com.focuslock.focuslockapp
--> group.com.focuslock.focuslockapp
-
-Suraj:
-com.focuslock.focuslock-app
--> group.com.focuslock.focuslock-app
-```
-
-It also helped us prove the feature works. After the fallback produced the correct local group, App Group storage started working and closed-app blocking succeeded.
-
-### Why this still needs cleanup
-
-The confusing part is that the code still has two possible sources:
-
-```text
-1. Info.plist key
-2. bundle identifier fallback
-```
-
-That is why we created ticket #34. Long-term, we should choose one source of truth.
-
-This is tracked for cleanup in:
-
-```text
-#34 Fix App Group runtime configuration source
-```
-
-Long-term, we should choose one clean source of truth:
-
-```text
-Option A: make Info.plist key work reliably
-Option B: always derive from bundle ID and remove unused Info.plist plumbing
+APP_BUNDLE_ID = com.focuslock.focuslock-app
+APP_GROUP_IDENTIFIER = group.com.focuslock.focuslock-app
 ```
 
 ## 14. Diagnostics

--- a/focus-lock/Config/Local.example.xcconfig
+++ b/focus-lock/Config/Local.example.xcconfig
@@ -1,5 +1,9 @@
 // Copy this file to Local.xcconfig and replace the values with your Apple
 // Developer account settings. Local.xcconfig is ignored by Git.
+//
+// APP_GROUP_IDENTIFIER must be the exact App Group enabled for both the
+// focus-lock app target and the FocusLockDeviceActivityMonitor extension.
+// Xcode writes this same value into entitlements and Info.plist.
 
 DEVELOPMENT_TEAM = YOUR_TEAM_ID
 APP_BUNDLE_ID = com.yourname.focuslock

--- a/focus-lock/Config/focus-lock-Info.plist
+++ b/focus-lock/Config/focus-lock-Info.plist
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>focus-lock</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>FocusLockAppGroupIdentifier</key>
+	<string>$(APP_GROUP_IDENTIFIER)</string>
+	<key>LSApplicationCategoryType</key>
+	<string>public.app-category.productivity</string>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<true/>
+		<key>UISceneConfigurations</key>
+		<dict/>
+	</dict>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
+	<key>UILaunchScreen</key>
+	<dict/>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~iphone</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/focus-lock/Shared/FocusLockConfiguration.swift
+++ b/focus-lock/Shared/FocusLockConfiguration.swift
@@ -14,8 +14,10 @@ enum FocusLockConfiguration {
 
     // This is the Info.plist key where we store the resolved App Group identifier.
     //
-    // In project.pbxproj, we set:
+    // In the main app target, project.pbxproj sets:
     // INFOPLIST_KEY_FocusLockAppGroupIdentifier = "$(APP_GROUP_IDENTIFIER)";
+    //
+    // In the DeviceActivity monitor extension, Info.plist contains the same key.
     //
     // At build time, Xcode replaces $(APP_GROUP_IDENTIFIER) with something like:
     // group.com.focuslock.focuslockapp
@@ -25,15 +27,21 @@ enum FocusLockConfiguration {
     //
     // It looks like a variable, but it runs code each time we ask for it.
     static var appGroupIdentifier: String {
-        if let appGroup = infoPlistAppGroupIdentifier {
-            return appGroup
+        guard let appGroup = infoPlistAppGroupIdentifier else {
+            fatalError(
+                """
+                Missing \(appGroupInfoKey) in Info.plist. Set APP_GROUP_IDENTIFIER \
+                in focus-lock/Config/Local.xcconfig so Xcode writes the same App \
+                Group into Info.plist and the target entitlements.
+                """
+            )
         }
 
-        return derivedAppGroupIdentifier
+        return appGroup
     }
 
     static var appGroupSource: String {
-        infoPlistAppGroupIdentifier == nil ? "bundle identifier fallback" : "Info.plist"
+        "Info.plist"
     }
 
     private static var infoPlistAppGroupIdentifier: String? {
@@ -59,23 +67,5 @@ enum FocusLockConfiguration {
         }
 
         return nil
-    }
-
-    private static var derivedAppGroupIdentifier: String {
-        // Fallback value derived from the current bundle identifier.
-        //
-        // Ideally we do not use this, because the xcconfig/project setting should provide
-        // the real value. But if the Info.plist key is missing, deriving from the bundle
-        // ID is safer than hardcoding one developer's App Group.
-        //
-        // Examples:
-        // com.focuslock.focuslockapp -> group.com.focuslock.focuslockapp
-        // com.focuslock.focuslockapp.FocusLockDeviceActivityMonitor -> group.com.focuslock.focuslockapp
-        let bundleID = Bundle.main.bundleIdentifier ?? "com.focuslock.focuslock-app"
-        let baseBundleID = bundleID
-            .replacingOccurrences(of: ".FocusLockDeviceActivityMonitor", with: "")
-            .replacingOccurrences(of: ".FocusLockShieldConfiguration", with: "")
-
-        return "group.\(baseBundleID)"
     }
 }

--- a/focus-lock/focus-lock.xcodeproj/project.pbxproj
+++ b/focus-lock/focus-lock.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		71209C302F1429F4008313C6 /* Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Shared.xcconfig; sourceTree = "<group>"; };
 		71209C312F1429F4008313C6 /* Local.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.example.xcconfig; sourceTree = "<group>"; };
 		71209C332F1429F4008313C6 /* Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Local.xcconfig; sourceTree = "<group>"; };
+		71209C342F1429F4008313C6 /* focus-lock-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "focus-lock-Info.plist"; sourceTree = "<group>"; };
 		DA0000012FAF00000012076D /* DeviceActivity.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = DeviceActivity.framework; path = System/Library/Frameworks/DeviceActivity.framework; sourceTree = SDKROOT; };
 		DA0000022FAF00000012076D /* FamilyControls.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = FamilyControls.framework; path = System/Library/Frameworks/FamilyControls.framework; sourceTree = SDKROOT; };
 		DA0000042FAF00000012076D /* FocusLockDeviceActivityMonitor.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = FocusLockDeviceActivityMonitor.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -172,6 +173,7 @@
 				71209C302F1429F4008313C6 /* Shared.xcconfig */,
 				71209C312F1429F4008313C6 /* Local.example.xcconfig */,
 				71209C332F1429F4008313C6 /* Local.xcconfig */,
+				71209C342F1429F4008313C6 /* focus-lock-Info.plist */,
 			);
 			path = Config;
 			sourceTree = "<group>";
@@ -505,15 +507,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "focus-lock";
-				INFOPLIST_KEY_FocusLockAppGroupIdentifier = "$(APP_GROUP_IDENTIFIER)";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Config/focus-lock-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -544,15 +539,8 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = "focus-lock";
-				INFOPLIST_KEY_FocusLockAppGroupIdentifier = "$(APP_GROUP_IDENTIFIER)";
-				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.productivity";
-				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = "Config/focus-lock-Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
## Summary

Fixes #34 by making the App Group runtime configuration source explicit and reliable.

## What Changed

- Added `AGENTS.md` so future Codex sessions and reviewers have the durable Focus Lock project context attached to this branch.
- Added `focus-lock/Config/focus-lock-Info.plist` for the main app target.
- Switched the main app target from generated Info.plist settings to the explicit plist file so `FocusLockAppGroupIdentifier` is present in the built app bundle.
- Updated `FocusLockConfiguration` to require `FocusLockAppGroupIdentifier` from Info.plist instead of silently deriving an App Group from the bundle ID.
- Updated local config guidance and the DeviceActivity deep dive to explain that `APP_GROUP_IDENTIFIER` feeds both entitlements and runtime lookup.

## Why

The monitor extension already had `FocusLockAppGroupIdentifier`, but the generated main app Info.plist was not actually including the custom key at runtime. That left the app with confusing fallback behavior and could hide signing/runtime mismatches.

This PR makes `APP_GROUP_IDENTIFIER` the single source for both sides:

```text
Local.xcconfig
  -> entitlements for App Group access
  -> Info.plist for runtime FileManager lookup
```

## Validation

- `plutil -lint focus-lock/Config/focus-lock-Info.plist`
- `git diff --check`
- `xcodebuild -project focus-lock/focus-lock.xcodeproj -scheme focus-lock -configuration Debug -destination generic/platform=iOS -derivedDataPath /private/tmp/focus-lock-derived CODE_SIGNING_ALLOWED=NO build`
- Verified Shabarish build output contains:
  - app bundle id: `com.focuslock.focuslockapp`
  - app group: `group.com.focuslock.focuslockapp`
  - monitor extension group: `group.com.focuslock.focuslockapp`
- Verified Suraj override build output contains:
  - app bundle id: `com.focuslock.focuslock-app`
  - app group: `group.com.focuslock.focuslock-app`
  - monitor extension group: `group.com.focuslock.focuslock-app`

## Real Device Check

Shabarish deleted/reinstalled the app, deleted existing rules, created/saved rules again, and confirmed rule persistence behavior works without App Group entitlement errors.