### PR TITLE
Fixed Category and Website Selection and Updated UI

### DIFF
--- a/focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -70,11 +70,32 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
 
         // Ask the shared schedule helper which app tokens should be blocked at this moment.
         let activeApplicationTokens = FocusLockSchedule.activeApplicationTokens(from: rules)
-        FocusLockDiagnostics.record("DeviceActivityMonitor active token count: \(activeApplicationTokens.count).")
 
-        // If the set is empty, use nil to remove shields.
+        // Ask the shared schedule helper which app category tokens should be blocked at this moment.
+        let activeCategoryTokens = FocusLockSchedule.activeCategoryTokens(from: rules)
+
+        // Ask the shared schedule helper which web domain tokens should be blocked at this moment.
+        let activeWebDomainTokens = FocusLockSchedule.activeWebDomainTokens(from: rules)
+
+        // Record the active token counts so diagnostics show apps, categories, and websites separately.
+        FocusLockDiagnostics.record("DeviceActivityMonitor active token counts: apps=\(activeApplicationTokens.count), categories=\(activeCategoryTokens.count), webDomains=\(activeWebDomainTokens.count).")
+
+        // If the app token set is empty, use nil to remove direct app shields.
         // Otherwise, give iOS the exact selected app tokens to block.
         store.shield.applications = activeApplicationTokens.isEmpty ? nil : activeApplicationTokens
-        FocusLockDiagnostics.record(activeApplicationTokens.isEmpty ? "DeviceActivityMonitor cleared shields." : "DeviceActivityMonitor applied shields.")
+
+        // If the category token set is empty, use nil to remove category shields.
+        // Otherwise, give iOS the selected app categories to block.
+        store.shield.applicationCategories = activeCategoryTokens.isEmpty ? nil : .specific(activeCategoryTokens)
+
+        // If the web domain token set is empty, use nil to remove website shields.
+        // Otherwise, give iOS the exact selected web domains to block.
+        store.shield.webDomains = activeWebDomainTokens.isEmpty ? nil : activeWebDomainTokens
+
+        // Check whether any kind of shield is active after this refresh.
+        let hasActiveShields = !activeApplicationTokens.isEmpty || !activeCategoryTokens.isEmpty || !activeWebDomainTokens.isEmpty
+
+        // Record whether the monitor cleared every shield or applied at least one shield.
+        FocusLockDiagnostics.record(hasActiveShields ? "DeviceActivityMonitor applied shields." : "DeviceActivityMonitor cleared shields.")
     }
 }

--- a/focus-lock/FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
+++ b/focus-lock/FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
@@ -13,10 +13,9 @@ import UIKit
 // The system provides a default appearance for any methods that your subclass doesn't override.
 // Make sure that your class name matches the NSExtensionPrincipalClass in your Info.plist.
 class ShieldConfigurationExtension: ShieldConfigurationDataSource {
-    // iOS calls this when the user opens an app that Focus Lock has shielded.
-    // This config controls the system blocked screen shown over that app.
-    override func configuration(shielding application: Application) -> ShieldConfiguration {
-
+    // Builds the custom Focus Lock blocked screen that every shield type should reuse.
+    private func focusLockShieldConfiguration() -> ShieldConfiguration {
+        // Returns the title, subtitle, button text, and button color for the shield screen.
         return ShieldConfiguration(
             // Matches the title currently shown in BlockedView.
             title: .init(
@@ -41,18 +40,27 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
         )
     }
     
+    // iOS calls this when the user opens an app that was selected directly.
+    override func configuration(shielding application: Application) -> ShieldConfiguration {
+        // Shows the custom Focus Lock blocked screen for directly selected apps.
+        return focusLockShieldConfiguration()
+    }
+    
+    // iOS calls this when the user opens an app blocked because its category was selected.
     override func configuration(shielding application: Application, in category: ActivityCategory) -> ShieldConfiguration {
-        // Customize the shield as needed for applications shielded because of their category.
-        ShieldConfiguration()
+        // Shows the custom Focus Lock blocked screen for apps blocked through a category.
+        return focusLockShieldConfiguration()
     }
     
+    // iOS calls this when the user opens a web domain that was selected directly.
     override func configuration(shielding webDomain: WebDomain) -> ShieldConfiguration {
-        // Customize the shield as needed for web domains.
-        ShieldConfiguration()
+        // Shows the custom Focus Lock blocked screen for directly selected websites.
+        return focusLockShieldConfiguration()
     }
     
+    // iOS calls this when the user opens a web domain blocked because its category was selected.
     override func configuration(shielding webDomain: WebDomain, in category: ActivityCategory) -> ShieldConfiguration {
-        // Customize the shield as needed for web domains shielded because of their category.
-        ShieldConfiguration()
+        // Shows the custom Focus Lock blocked screen for websites blocked through a category.
+        return focusLockShieldConfiguration()
     }
 }

--- a/focus-lock/Shared/FocusLockSchedule.swift
+++ b/focus-lock/Shared/FocusLockSchedule.swift
@@ -26,6 +26,23 @@ enum FocusLockSchedule {
     // Keeping the minimum in one shared constant makes the UI validation and
     // schedule registration use the same rule.
     static let minimumMonitorDurationMinutes = 15
+    
+    
+    // Returns true when the picker has at least one selected app, category, or website.
+    static func hasSelectedActivity(_ selection: FamilyActivitySelection) -> Bool {
+        // Counts direct individual app selections.
+        let hasApps = !selection.applicationTokens.isEmpty
+
+        // Counts category selections, including category "Select All".
+        let hasCategories = !selection.categoryTokens.isEmpty
+
+        // Counts selected web domains if the user picks websites later.
+        let hasWebDomains = !selection.webDomainTokens.isEmpty
+
+        // Treat any of those three token sets as a valid saved selection.
+        return hasApps || hasCategories || hasWebDomains
+    }
+
 
     // Decides whether a rule is worth registering with DeviceActivity.
     //
@@ -37,9 +54,14 @@ enum FocusLockSchedule {
     // Apple throws intervalTooShort when we try tiny test windows like 2 minutes.
     // We use 15 minutes as our current development minimum.
     static func isMonitorable(_ rule: Rule) -> Bool {
-        rule.isEnabled &&
-        !rule.activitySelection.applicationTokens.isEmpty &&
-        durationMinutes(for: rule) >= minimumMonitorDurationMinutes
+        // Requires the rule toggle to be on.
+            rule.isEnabled &&
+
+            // Allows app, category, or web domain selections to count.
+            hasSelectedActivity(rule.activitySelection) &&
+
+            // Requires the schedule to meet Apple's DeviceActivity minimum duration.
+            durationMinutes(for: rule) >= minimumMonitorDurationMinutes
     }
 
     // Decides whether the current time is inside this rule's blocking window.
@@ -109,6 +131,32 @@ enum FocusLockSchedule {
 
                 // Add this rule's selected apps into the running Set.
                 selectedApps.formUnion(rule.activitySelection.applicationTokens)
+            }
+    }
+    
+    // Builds the active category tokens from currently active rules.
+    static func activeCategoryTokens(from rules: [Rule], now: Date = Date()) -> Set<ActivityCategoryToken> {
+        // Starts with rules that should apply right now.
+        rules.filter { isMonitorable($0) && isActive($0, now: now) }
+
+            // Combines all active category token sets into one set.
+            .reduce(into: Set<ActivityCategoryToken>()) { selectedCategories, rule in
+
+                // Adds this rule's selected categories.
+                selectedCategories.formUnion(rule.activitySelection.categoryTokens)
+            }
+    }
+
+    // Builds the active web domain tokens from currently active rules.
+    static func activeWebDomainTokens(from rules: [Rule], now: Date = Date()) -> Set<WebDomainToken> {
+        // Starts with rules that should apply right now.
+        rules.filter { isMonitorable($0) && isActive($0, now: now) }
+
+            // Combines all active web domain token sets into one set.
+            .reduce(into: Set<WebDomainToken>()) { selectedWebDomains, rule in
+
+                // Adds this rule's selected web domains.
+                selectedWebDomains.formUnion(rule.activitySelection.webDomainTokens)
             }
     }
 

--- a/focus-lock/focus-lock/ScreenTimeShieldManager.swift
+++ b/focus-lock/focus-lock/ScreenTimeShieldManager.swift
@@ -23,21 +23,35 @@ final class ScreenTimeShieldManager {
         //
         // This returns a Set<ApplicationToken>.
         // Empty set means no selected apps currently need shielding.
+        // Gets the active individual app tokens.
         let activeApplicationTokens = FocusLockSchedule.activeApplicationTokens(from: rules)
 
-        // If no rules are active right now, remove all shields.
-        //
-        // The ternary operator works like:
-        // condition ? valueIfTrue : valueIfFalse
-        //
-        // So this means:
-        // if activeApplicationTokens is empty, set shield.applications to nil;
-        // otherwise, set it to the tokens we should block.
+        // Gets the active app category tokens.
+        let activeCategoryTokens = FocusLockSchedule.activeCategoryTokens(from: rules)
+
+        // Gets the active web domain tokens.
+        let activeWebDomainTokens = FocusLockSchedule.activeWebDomainTokens(from: rules)
+
+        // Shields directly selected apps, or clears app shields if none are active.
         store.shield.applications = activeApplicationTokens.isEmpty ? nil : activeApplicationTokens
+
+        // Shields selected app categories, or clears category shields if none are active.
+        store.shield.applicationCategories = activeCategoryTokens.isEmpty ? nil : .specific(activeCategoryTokens)
+
+        // Shields selected web domains, or clears web domain shields if none are active.
+        store.shield.webDomains = activeWebDomainTokens.isEmpty ? nil : activeWebDomainTokens
+
     }
 
     // Removes all app shields managed by this store.
     func clearShields() {
+        // Removes directly selected app shields.
         store.shield.applications = nil
+
+        // Removes selected category shields.
+        store.shield.applicationCategories = nil
+
+        // Removes selected web domain shields.
+        store.shield.webDomains = nil
     }
 }

--- a/focus-lock/focus-lock/Views/CreateRuleView.swift
+++ b/focus-lock/focus-lock/Views/CreateRuleView.swift
@@ -20,6 +20,45 @@ struct CreateRuleView: View {
     @State private var showAppPicker = false
     // Controls the popup shown when the selected schedule is too short for DeviceActivity.
     @State private var showDurationAlert = false
+    
+    // Builds the text shown next to the app picker row.
+    private var selectedActivitySummary: String {
+        // Counts directly selected individual apps.
+        let appCount = activitySelection.applicationTokens.count
+
+        // Counts selected app categories, including category "Select All".
+        let categoryCount = activitySelection.categoryTokens.count
+
+        // Counts selected websites if the user selects web domains later.
+        let webDomainCount = activitySelection.webDomainTokens.count
+
+        // Stores each non-empty piece of the summary text.
+        var parts: [String] = []
+
+        // Adds an app summary when individual apps are selected.
+        if appCount > 0 {
+            parts.append("\(appCount) \(appCount == 1 ? "app" : "apps")")
+        }
+
+        // Adds a category summary when categories are selected.
+        if categoryCount > 0 {
+            parts.append("\(categoryCount) \(categoryCount == 1 ? "category" : "categories")")
+        }
+
+        // Adds a website summary when web domains are selected.
+        if webDomainCount > 0 {
+            parts.append("\(webDomainCount) \(webDomainCount == 1 ? "website" : "websites")")
+        }
+
+        // Shows zero selected when nothing has been picked yet.
+        if parts.isEmpty {
+            return "None Selected"
+        }
+
+        // Joins the non-empty pieces and adds the selected label at the end.
+        return parts.joined(separator: ", ") + " selected"
+    }
+
 
 
     var body: some View {
@@ -42,8 +81,10 @@ struct CreateRuleView: View {
                         HStack {
                             Text("Select Apps")
                             Spacer()
-                            Text("\(activitySelection.applicationTokens.count) selected")
+                            // Shows the total number of selected picker items.
+                            Text(selectedActivitySummary)
                                 .foregroundStyle(.secondary)
+
                         }
                     }
                 }
@@ -84,7 +125,7 @@ struct CreateRuleView: View {
 
                         dismiss()
                     }
-                    .disabled(ruleName.isEmpty || activitySelection.applicationTokens.isEmpty)
+                    .disabled(ruleName.isEmpty || !FocusLockSchedule.hasSelectedActivity(activitySelection))
                 }
             }
             // Explains why Save did not work when the schedule is under the minimum duration.

--- a/focus-lock/focus-lock/Views/EditRuleView.swift
+++ b/focus-lock/focus-lock/Views/EditRuleView.swift
@@ -37,6 +37,45 @@ struct EditRuleView: View {
     
     // Controls the popup shown when the edited schedule is too short for DeviceActivity.
     @State private var showDurationAlert = false
+    
+    // Builds the text shown next to the app picker row.
+    private var selectedActivitySummary: String {
+        // Counts directly selected individual apps.
+        let appCount = activitySelection.applicationTokens.count
+
+        // Counts selected app categories, including category "Select All".
+        let categoryCount = activitySelection.categoryTokens.count
+
+        // Counts selected websites if the user selects web domains later.
+        let webDomainCount = activitySelection.webDomainTokens.count
+
+        // Stores each non-empty piece of the summary text.
+        var parts: [String] = []
+
+        // Adds an app summary when individual apps are selected.
+        if appCount > 0 {
+            parts.append("\(appCount) \(appCount == 1 ? "app" : "apps")")
+        }
+
+        // Adds a category summary when categories are selected.
+        if categoryCount > 0 {
+            parts.append("\(categoryCount) \(categoryCount == 1 ? "category" : "categories")")
+        }
+
+        // Adds a website summary when web domains are selected.
+        if webDomainCount > 0 {
+            parts.append("\(webDomainCount) \(webDomainCount == 1 ? "website" : "websites")")
+        }
+
+        // Shows zero selected when nothing has been picked yet.
+        if parts.isEmpty {
+            return "None Selected"
+        }
+
+        // Joins the non-empty pieces and adds the selected label at the end.
+        return parts.joined(separator: ", ") + " selected"
+    }
+
 
 
     // Runs when this edit screen is created with a specific rule.
@@ -94,7 +133,7 @@ struct EditRuleView: View {
                             Spacer()
 
                             // Shows how many apps are currently selected.
-                            Text("\(activitySelection.applicationTokens.count) selected")
+                            Text(selectedActivitySummary)
                                 // Makes the selected count use secondary text styling.
                                 .foregroundStyle(.secondary)
                         }
@@ -151,7 +190,7 @@ struct EditRuleView: View {
 
 
                     // Prevents saving when required fields are missing.
-                    .disabled(ruleName.isEmpty || activitySelection.applicationTokens.isEmpty)
+                    .disabled(ruleName.isEmpty || !FocusLockSchedule.hasSelectedActivity(activitySelection))
                 }
             }
             // Explains why Save did not work when the schedule is under the minimum duration.

--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -17,6 +17,43 @@ struct RulesView: View {
     
     @State private var goToBlocked = false
     
+    // Builds the saved selection text for one rule in the rules list.
+    private func selectedActivitySummary(for rule: Rule) -> String {
+        // Counts directly selected individual apps.
+        let appCount = rule.activitySelection.applicationTokens.count
+
+        // Counts selected app categories, including category "Select All".
+        let categoryCount = rule.activitySelection.categoryTokens.count
+
+        // Counts selected websites if the user selects web domains later.
+        let webDomainCount = rule.activitySelection.webDomainTokens.count
+
+        // Stores each non-empty piece of the summary text.
+        var parts: [String] = []
+
+        // Adds an app summary when individual apps are selected.
+        if appCount > 0 {
+            parts.append("\(appCount) \(appCount == 1 ? "app" : "apps")")
+        }
+
+        // Adds a category summary when categories are selected.
+        if categoryCount > 0 {
+            parts.append("\(categoryCount) \(categoryCount == 1 ? "category" : "categories")")
+        }
+
+        // Adds a website summary when web domains are selected.
+        if webDomainCount > 0 {
+            parts.append("\(webDomainCount) \(webDomainCount == 1 ? "website" : "websites")")
+        }
+
+        // Shows zero selected when nothing has been picked yet.
+        if parts.isEmpty {
+            return "None Selected"
+        }
+
+        // Joins the non-empty pieces and adds the selected label at the end.
+        return parts.joined(separator: ", ") + " selected"
+    }
     
     @EnvironmentObject var appState: AppState
     
@@ -88,7 +125,9 @@ struct RulesView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.gray)
                             
-                            Text("\(rule.activitySelection.applicationTokens.count) app(s) selected")
+                            
+                            // Shows how many picker items this rule contains.
+                            Text(selectedActivitySummary(for: rule))
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }


### PR DESCRIPTION
## Summary

This PR fixes how Focus Lock handles app category selections from Apple’s Screen Time picker.

Before this change, the app mostly worked when a user selected individual apps one by one. For example, if the user selected Instagram directly, Focus Lock could count it, save the rule, schedule it, and block it.

The problem happened when the user selected an entire app category using Apple’s picker, like selecting all apps in a category. In that case, Apple does not save every app inside that category as individual app selections. Instead, Apple saves that choice as a category selection.

Our code was mostly only looking for individual app selections, so category selections looked empty to Focus Lock even though the user had actually selected something.

This PR updates the app so it understands three possible selection types:

```swift
applicationTokens
categoryTokens
webDomainTokens
```

In plain English:

- `applicationTokens` means apps the user selected directly.
- `categoryTokens` means app categories the user selected.
- `webDomainTokens` means websites the user selected.

## What Was Broken Before

The app was checking this in several places:

```swift
activitySelection.applicationTokens
```

That only works for directly selected apps.

So if a user selected a whole category, the category was saved inside:

```swift
activitySelection.categoryTokens
```

But our app was not counting that as a valid selection in enough places.

That caused a few different bugs:

1. The Create Rule screen could say nothing was selected.
2. The Save button could stay disabled.
3. The rule could fail to register for closed-app enforcement.
4. The app might not apply the category shield correctly.
5. Apps blocked through a category could show Apple’s default restricted screen instead of our custom Focus Lock blocked screen.

## Why Apple Behaves This Way

Apple’s Screen Time APIs are privacy-preserving. When a user selects a category, Apple does not necessarily hand us a list of every app inside that category.

So selecting a category does not mean:

```swift
applicationTokens = [Instagram, TikTok, Snapchat, ...]
```

Instead, it means something closer to:

```swift
categoryTokens = [Social]
```

That means our app cannot honestly say “15 apps selected” when a category is selected, because Apple does not give us that exact app count.

So the UI now says things like:

```text
1 category selected
```

or:

```text
2 apps, 1 category selected
```

That is more accurate than pretending category selections are individual app selections.

## Files Changed

### `Shared/FocusLockSchedule.swift`

This file contains shared schedule logic used by both the main app and the DeviceActivity monitor extension.

I added a helper called:

```swift
hasSelectedActivity(_:)
```

This checks whether a `FamilyActivitySelection` contains at least one of these:

```swift
applicationTokens
categoryTokens
webDomainTokens
```

Before, a rule was only considered valid for scheduling if it had at least one direct app token.

Now, a rule can be considered valid if it has:

- at least one selected app
- at least one selected category
- at least one selected web domain

I also added helpers for active category and website selections:

```swift
activeCategoryTokens(from:)
activeWebDomainTokens(from:)
```

We already had:

```swift
activeApplicationTokens(from:)
```

But that only handled direct app selections. The new helpers let the app and extension figure out which categories and websites should be blocked during an active rule window.

### `focus-lock/Views/CreateRuleView.swift`

This is the screen where a user creates a new rule.

I changed the selected item display so it no longer only counts direct apps.

Before, it used:

```swift
activitySelection.applicationTokens.count
```

That made category selections show up incorrectly.

Now the display looks at apps, categories, and websites.

Examples of the new display:

```text
1 app selected
2 apps selected
1 category selected
2 categories selected
2 apps, 1 category selected
1 website selected
```

I also changed the Save button validation.

Before, Save was disabled if there were no direct app tokens:

```swift
activitySelection.applicationTokens.isEmpty
```

Now Save is disabled only if there are no apps, no categories, and no web domains selected.

That means selecting a category now counts as a real selection.

### `focus-lock/Views/EditRuleView.swift`

This is the screen where a user edits an existing rule.

I made the same updates here as Create Rule.

That way, creating a rule and editing a rule behave consistently.

The edit screen now:

- shows apps, categories, and websites correctly
- allows saving when a category is selected
- does not rely only on direct app tokens

### `focus-lock/Views/RulesView.swift`

This is the screen that lists the saved rules.

Before, each saved rule displayed only this:

```swift
rule.activitySelection.applicationTokens.count
```

So a category-only rule could look like it had no selected apps, even though it had a category saved.

I changed this to use a helper function that builds a readable summary for each rule.

For example:

```text
1 category selected
```

instead of:

```text
0 app(s) selected
```

This makes the saved rules list match what the user actually selected.

### `focus-lock/ScreenTimeShieldManager.swift`

This file applies shields while the main app is open.

Before, it only applied app shields:

```swift
store.shield.applications
```

That means it only handled directly selected apps.

I updated it to apply three kinds of shields:

```swift
store.shield.applications
store.shield.applicationCategories
store.shield.webDomains
```

Now the main app can immediately block:

- directly selected apps
- selected app categories
- selected web domains

I also updated `clearShields()` so it clears all three shield types, not just direct app shields.

### `FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift`

This is the extension that iOS wakes up when a scheduled rule starts or ends.

This matters because Focus Lock needs to keep blocking apps even when the main app is closed.

Before, the extension only loaded active direct app tokens and applied:

```swift
store.shield.applications
```

Now it also loads and applies:

```swift
store.shield.applicationCategories
store.shield.webDomains
```

So category-based rules should still work when the app is closed.

I also updated the diagnostics message so it reports counts separately:

```text
apps=...
categories=...
webDomains=...
```

That should make debugging easier later because we can tell what kind of selections were active.

### `FocusLockShieldConfiguration/ShieldConfigurationExtension.swift`

This file controls the blocked screen UI shown by iOS.

Before, our custom Focus Lock blocked screen was only returned from this method:

```swift
configuration(shielding application: Application)
```

That method is used when a directly selected app is blocked.

But when an app is blocked because it belongs to a selected category, iOS calls a different method:

```swift
configuration(shielding application: Application, in category: ActivityCategory)
```

That category method was returning:

```swift
ShieldConfiguration()
```

That is basically the default/empty configuration, so iOS showed Apple’s default restricted screen instead of our custom Focus Lock shield.

I fixed this by moving our custom shield UI into one shared helper:

```swift
focusLockShieldConfiguration()
```

Then I made all shield cases return that same custom screen:

- directly selected apps
- apps blocked through selected categories
- directly selected websites
- websites blocked through selected categories

This keeps the blocked screen consistent no matter how the app or website was selected.

## Important Concept

There are two separate things happening in this PR:

### 1. Saving and counting the selection

This is the UI/validation part.

It makes sure the app understands that category selections are real selections.

### 2. Actually blocking the selection

This is the enforcement part.

It makes sure Focus Lock applies shields for categories and web domains, not just individual apps.

Both parts were needed. If we only fixed the UI, the user might be able to save the rule, but the rule might not actually block correctly. If we only fixed the blocking logic, the user might still be unable to save the rule from the Create Rule screen.

## User-Facing Behavior After This PR

After this PR:

1. A user can open Create Rule.
2. A user can select a whole app category.
3. The Create Rule screen should show something like:

```text
1 category selected
```

4. The Save button should become enabled.
5. The saved rule should show the category selection correctly in the Rules list.
6. During the active schedule window, apps in that category should be blocked.
7. Apps blocked through a category should show the custom Focus Lock shield screen, not Apple’s default restricted screen.
8. The same behavior should work while the app is open and when iOS wakes the DeviceActivity monitor extension while the app is closed.

## Testing Notes

This should be tested on a real iPhone because Apple’s Screen Time APIs are not reliable in the simulator.

Recommended test plan:

1. Build and run the app on a real iPhone.
2. Create a rule by selecting one individual app.
3. Confirm the picker row says:

```text
1 app selected
```

4. Save the rule.
5. Confirm the rule appears correctly in the Rules list.
6. During the active rule window, open that app and confirm it is blocked.
7. Create another rule by selecting a whole app category.
8. Confirm the picker row says:

```text
1 category selected
```

9. Save the rule.
10. Confirm the rule appears correctly in the Rules list.
11. Open an app inside that selected category.
12. Confirm the app is blocked.
13. Confirm the blocked screen uses our custom Focus Lock screen.
14. Leave the Focus Lock app normally.
15. Wait for a scheduled rule window handled by DeviceActivity.
16. Confirm category-selected apps are still blocked while the main app is closed.

## Notes / Limitations

Apple does not give us the exact number of apps inside a selected category.

So the app should not display:

```text
15 apps selected
```

for a category selection.

Instead, it displays:

```text
1 category selected
```

This is expected behavior and matches the data Apple gives us.
