### PR TITLE
Created option for recurring vs one time rules

### DIFF
--- a/focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -22,6 +22,9 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
     // Setting store.shield.applications blocks apps.
     // Setting store.shield.applications = nil removes app shields from this store.
     private let store = ManagedSettingsStore()
+    
+    // DeviceActivityCenter lets the extension stop monitoring a completed one-time rule.
+    private let center = DeviceActivityCenter()
 
     // iOS calls this when one of our monitored rule intervals starts.
     //
@@ -47,6 +50,9 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
         FocusLockDiagnostics.record("DeviceActivityMonitor intervalDidEnd fired for \(activity.rawValue).")
 
         super.intervalDidEnd(for: activity)
+        
+        // Remove a completed one-time rule before recalculating shields.
+        deleteCompletedOneTimeRuleIfNeeded(for: activity)
 
         // Recompute instead of blindly clearing everything.
         //
@@ -97,5 +103,55 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
 
         // Record whether the monitor cleared every shield or applied at least one shield.
         FocusLockDiagnostics.record(hasActiveShields ? "DeviceActivityMonitor applied shields." : "DeviceActivityMonitor cleared shields.")
+    }
+    
+    // Deletes a one-time rule after iOS tells us its interval ended.
+    private func deleteCompletedOneTimeRuleIfNeeded(for activity: DeviceActivityName) {
+        // Pull the rule id out of the DeviceActivityName.
+        guard let endedRuleID = activity.focusLockRuleID else {
+            // Record that this activity was not one of our rule schedules.
+            FocusLockDiagnostics.record("DeviceActivityMonitor could not find a Focus Lock rule id for \(activity.rawValue).")
+            // Stop because there is no rule id to delete.
+            return
+        }
+        
+        // Load the latest rules from shared App Group storage.
+        let rules = FocusLockRuleStore.loadRules()
+        
+        // Find the rule whose schedule just ended.
+        guard let endedRule = rules.first(where: { $0.id == endedRuleID }) else {
+            // Record that the rule may have already been deleted.
+            FocusLockDiagnostics.record("DeviceActivityMonitor found no saved rule for ended activity \(activity.rawValue).")
+            // Stop because there is no saved rule to delete.
+            return
+        }
+        
+        // Only one-time rules should delete themselves after ending.
+        guard endedRule.isOneTime else {
+            // Record that recurring rules stay saved after each interval ends.
+            FocusLockDiagnostics.record("DeviceActivityMonitor leaving recurring rule \(endedRule.id) saved after interval end.")
+            // Stop because recurring rules should keep repeating.
+            return
+        }
+        
+        // Make sure the one-time rule has truly reached its end time.
+        guard FocusLockSchedule.isCompletedOneTimeRule(endedRule) else {
+            // Record that iOS called intervalDidEnd but our schedule math does not consider the rule completed yet.
+            FocusLockDiagnostics.record("DeviceActivityMonitor did not delete one-time rule \(endedRule.id) because it is not completed yet.")
+            // Stop because deleting early would be confusing and risky.
+            return
+        }
+        
+        // Build a new rules array without the completed one-time rule.
+        let remainingRules = rules.filter { $0.id != endedRuleID }
+        
+        // Save the updated rules array back to App Group storage.
+        FocusLockRuleStore.saveRules(remainingRules)
+        
+        // Tell iOS to stop monitoring this completed one-time schedule.
+        center.stopMonitoring([activity])
+        
+        // Record that the one-time rule was removed successfully.
+        FocusLockDiagnostics.record("DeviceActivityMonitor deleted completed one-time rule \(endedRule.id).")
     }
 }

--- a/focus-lock/FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
+++ b/focus-lock/FocusLockShieldConfiguration/ShieldConfigurationExtension.swift
@@ -17,26 +17,32 @@ class ShieldConfigurationExtension: ShieldConfigurationDataSource {
     private func focusLockShieldConfiguration() -> ShieldConfiguration {
         // Returns the title, subtitle, button text, and button color for the shield screen.
         return ShieldConfiguration(
-            // Matches the title currently shown in BlockedView.
+            // Uses a deep focus color behind the shield screen instead of the default background.
+            backgroundColor: UIColor(red: 0.05, green: 0.09, blue: 0.12, alpha: 1.0),
+            
+            // Shows a lock-and-shield symbol so the screen feels protected, not like a timer.
+            icon: UIImage(systemName: "lock.shield.fill"),
+            
+            // Shows a calm title that makes the block feel intentional.
             title: .init(
-                text: "App is blocked",
-                color: .label
+                text: "Focus Lock is active",
+                color: .white
             ),
 
-            // Adds a short explanation because shield screens support a subtitle area.
+            // Reminds the user that this block protects the focus session they chose.
             subtitle: .init(
-                text: "Focus Lock is keeping you away from this app.",
-                color: .secondaryLabel
+                text: "You locked this app",
+                color: .lightText
             ),
 
-            // Matches the button currently shown in BlockedView.
+            // Keeps the current unlock payment action for now.
             primaryButtonLabel: .init(
                 text: "Pay $5 to unlock",
                 color: .white
             ),
 
-            // Makes the primary action look like a real call-to-action button.
-            primaryButtonBackgroundColor: .systemBlue
+            // Uses a focused green button color that stands out against the dark background.
+            primaryButtonBackgroundColor: UIColor(red: 0.10, green: 0.55, blue: 0.35, alpha: 1.0)
         )
     }
     

--- a/focus-lock/Shared/FocusLockSchedule.swift
+++ b/focus-lock/Shared/FocusLockSchedule.swift
@@ -3,241 +3,493 @@
 //  focus-lock
 //
 
-// DeviceActivity provides DeviceActivitySchedule and DeviceActivityName.
-// These are the APIs that let iOS wake our extension at schedule boundaries.
+// Imports Apple's scheduling types that wake the monitor extension.
 import DeviceActivity
 
-// FamilyControls provides FamilyActivitySelection, which is part of Rule.
+// Imports Apple's Screen Time picker selection type.
 import FamilyControls
 
-// Foundation provides Date, Calendar, DateComponents, UUID, Set, etc.
+// Imports basic Swift date, calendar, UUID, and collection types.
 import Foundation
 
-// ManagedSettings provides ApplicationToken.
-// This is why the earlier build error happened: ApplicationToken was not in scope.
+// Imports Apple's shield token types for apps, categories, and websites.
 import ManagedSettings
 
-// Shared schedule helpers.
-//
-// The app and the DeviceActivity extension should agree on schedule behavior.
-// So the "is this rule active right now?" logic lives here once instead of being copied.
+// Groups all shared schedule helper functions in one place.
 enum FocusLockSchedule {
-    // DeviceActivity can reject very short schedules with an intervalTooShort error.
-    // Keeping the minimum in one shared constant makes the UI validation and
-    // schedule registration use the same rule.
+    // Stores the shortest rule duration DeviceActivity should try to monitor.
     static let minimumMonitorDurationMinutes = 15
-    
-    
-    // Returns true when the picker has at least one selected app, category, or website.
+
+    // Stores weekdays in the order we want to show them.
+    static let weekdayDisplayOrder = [1, 2, 3, 4, 5, 6, 7]
+
+    // Stores short text labels for each weekday number.
+    static let weekdayShortLabels: [Int: String] = [
+        // Stores the label for Sunday.
+        1: "Sun",
+        // Stores the label for Monday.
+        2: "Mon",
+        // Stores the label for Tuesday.
+        3: "Tue",
+        // Stores the label for Wednesday.
+        4: "Wed",
+        // Stores the label for Thursday.
+        5: "Thu",
+        // Stores the label for Friday.
+        6: "Fri",
+        // Stores the label for Saturday.
+        7: "Sat"
+    ]
+
+    // Checks whether the user selected any apps, categories, or websites.
     static func hasSelectedActivity(_ selection: FamilyActivitySelection) -> Bool {
-        // Counts direct individual app selections.
+        // Checks whether individual apps were selected.
         let hasApps = !selection.applicationTokens.isEmpty
 
-        // Counts category selections, including category "Select All".
+        // Checks whether app categories were selected.
         let hasCategories = !selection.categoryTokens.isEmpty
 
-        // Counts selected web domains if the user picks websites later.
+        // Checks whether websites were selected.
         let hasWebDomains = !selection.webDomainTokens.isEmpty
 
-        // Treat any of those three token sets as a valid saved selection.
+        // Returns true if any selectable Screen Time item was picked.
         return hasApps || hasCategories || hasWebDomains
     }
 
+    // Checks whether a rule should be registered with DeviceActivity.
+    static func isMonitorable(_ rule: Rule, now: Date = Date()) -> Bool {
+        // Checks that the rule is turned on.
+        let isEnabled = rule.isEnabled
 
-    // Decides whether a rule is worth registering with DeviceActivity.
-    //
-    // A rule is monitorable if:
-    // 1. It is enabled.
-    // 2. The user selected at least one app.
-    // 3. The interval is long enough for DeviceActivity to accept.
-    //
-    // Apple throws intervalTooShort when we try tiny test windows like 2 minutes.
-    // We use 15 minutes as our current development minimum.
-    static func isMonitorable(_ rule: Rule) -> Bool {
-        // Requires the rule toggle to be on.
-            rule.isEnabled &&
+        // Checks that the rule has something to block.
+        let hasActivity = hasSelectedActivity(rule.activitySelection)
 
-            // Allows app, category, or web domain selections to count.
-            hasSelectedActivity(rule.activitySelection) &&
+        // Checks that the rule is long enough for DeviceActivity.
+        let hasEnoughDuration = durationMinutes(for: rule) >= minimumMonitorDurationMinutes
 
-            // Requires the schedule to meet Apple's DeviceActivity minimum duration.
-            durationMinutes(for: rule) >= minimumMonitorDurationMinutes
+        // Checks that recurrence data is valid.
+        let recurrenceIsValid = hasValidRecurrence(rule)
+
+        // Checks that a one-time rule has not already ended.
+        let hasNotCompleted = !isCompletedOneTimeRule(rule, now: now)
+
+        // Returns true only when every required condition is true.
+        return isEnabled && hasActivity && hasEnoughDuration && recurrenceIsValid && hasNotCompleted
     }
 
-    // Decides whether the current time is inside this rule's blocking window.
-    //
-    // now: Date = Date() means:
-    // "If the caller does not pass a time, use the current time."
+    // Checks whether the rule has usable recurrence settings.
+    static func hasValidRecurrence(_ rule: Rule) -> Bool {
+        // Recurring rules are valid when at least one weekday is selected.
+        if rule.isRecurring {
+            // Tells the caller this recurring rule is valid.
+            return true
+        }
+
+        // One-time rules are valid only when they have a calendar date.
+        return rule.oneTimeDate != nil
+    }
+
+    // Checks whether the current time is inside this rule's blocking window.
     static func isActive(_ rule: Rule, now: Date = Date()) -> Bool {
-
-        // Convert all times into minutes since midnight.
-        //
-        // Example:
-        // 9:30 AM becomes 570.
-        // 8:41 PM becomes 1241.
-        let nowMinutes = minutesSinceMidnight(now)
-        let startMinutes = minutesSinceMidnight(rule.startTime)
-        let endMinutes = minutesSinceMidnight(rule.endTime)
-
-        // Same-day schedule.
-        //
-        // Example:
-        // start = 9:00 AM
-        // end = 5:00 PM
-        //
-        // Active if now is >= start AND now is < end.
-        if startMinutes < endMinutes {
-            return nowMinutes >= startMinutes && nowMinutes < endMinutes
+        // Uses exact dates for one-time rules.
+        if rule.isOneTime {
+            // Returns whether this exact one-time session is active now.
+            return isOneTimeRuleActive(rule, now: now)
         }
 
-        // Overnight schedule.
-        //
-        // Example:
-        // start = 10:00 PM
-        // end = 6:00 AM
-        //
-        // This crosses midnight, so it is active if now is after start OR before end.
-        if startMinutes > endMinutes {
-            return nowMinutes >= startMinutes || nowMinutes < endMinutes
-        }
-
-        // If start and end are the same, we currently treat the rule as inactive.
-        // Later we could decide that same start/end means "block all day."
-        return false
+        // Returns whether this recurring rule is active now.
+        return isRecurringRuleActive(rule, now: now)
     }
 
-    // Builds the exact set of app tokens that should be shielded right now.
-    //
-    // Set<ApplicationToken> means:
-    // "A unique collection of selected app tokens."
-    //
-    // We use a Set instead of an Array because the same app could appear in multiple rules,
-    // but we only need to shield it once.
+    // Builds the app tokens that should be blocked right now.
     static func activeApplicationTokens(from rules: [Rule], now: Date = Date()) -> Set<ApplicationToken> {
-        rules
-            // filter keeps only the rules that should apply right now.
-            //
-            // $0 means "the current rule in the array."
-            .filter { isMonitorable($0) && isActive($0, now: now) }
+        // Starts with an empty set so duplicate app tokens collapse into one value.
+        var activeTokens = Set<ApplicationToken>()
 
-            // reduce combines many rules into one Set<ApplicationToken>.
-            //
-            // into: Set<ApplicationToken>() means:
-            // "Start with an empty Set of app tokens."
-            //
-            // selectedApps is the running Set we are building.
-            // rule is the current rule from the filtered rules array.
-            .reduce(into: Set<ApplicationToken>()) { selectedApps, rule in
-
-                // Add this rule's selected apps into the running Set.
-                selectedApps.formUnion(rule.activitySelection.applicationTokens)
+        // Looks at every saved rule one at a time.
+        for rule in rules {
+            // Skips rules that should not currently block anything.
+            guard isMonitorable(rule, now: now) && isActive(rule, now: now) else {
+                // Moves on to the next rule.
+                continue
             }
+
+            // Adds this rule's selected apps into the shared active set.
+            activeTokens.formUnion(rule.activitySelection.applicationTokens)
+        }
+
+        // Gives the caller the full set of apps to shield.
+        return activeTokens
     }
-    
-    // Builds the active category tokens from currently active rules.
+
+    // Builds the category tokens that should be blocked right now.
     static func activeCategoryTokens(from rules: [Rule], now: Date = Date()) -> Set<ActivityCategoryToken> {
-        // Starts with rules that should apply right now.
-        rules.filter { isMonitorable($0) && isActive($0, now: now) }
+        // Starts with an empty set so duplicate categories collapse into one value.
+        var activeTokens = Set<ActivityCategoryToken>()
 
-            // Combines all active category token sets into one set.
-            .reduce(into: Set<ActivityCategoryToken>()) { selectedCategories, rule in
-
-                // Adds this rule's selected categories.
-                selectedCategories.formUnion(rule.activitySelection.categoryTokens)
+        // Looks at every saved rule one at a time.
+        for rule in rules {
+            // Skips rules that should not currently block anything.
+            guard isMonitorable(rule, now: now) && isActive(rule, now: now) else {
+                // Moves on to the next rule.
+                continue
             }
+
+            // Adds this rule's selected categories into the shared active set.
+            activeTokens.formUnion(rule.activitySelection.categoryTokens)
+        }
+
+        // Gives the caller the full set of categories to shield.
+        return activeTokens
     }
 
-    // Builds the active web domain tokens from currently active rules.
+    // Builds the website tokens that should be blocked right now.
     static func activeWebDomainTokens(from rules: [Rule], now: Date = Date()) -> Set<WebDomainToken> {
-        // Starts with rules that should apply right now.
-        rules.filter { isMonitorable($0) && isActive($0, now: now) }
+        // Starts with an empty set so duplicate websites collapse into one value.
+        var activeTokens = Set<WebDomainToken>()
 
-            // Combines all active web domain token sets into one set.
-            .reduce(into: Set<WebDomainToken>()) { selectedWebDomains, rule in
-
-                // Adds this rule's selected web domains.
-                selectedWebDomains.formUnion(rule.activitySelection.webDomainTokens)
+        // Looks at every saved rule one at a time.
+        for rule in rules {
+            // Skips rules that should not currently block anything.
+            guard isMonitorable(rule, now: now) && isActive(rule, now: now) else {
+                // Moves on to the next rule.
+                continue
             }
+
+            // Adds this rule's selected websites into the shared active set.
+            activeTokens.formUnion(rule.activitySelection.webDomainTokens)
+        }
+
+        // Gives the caller the full set of websites to shield.
+        return activeTokens
     }
 
-    // Converts one Rule into the schedule object Apple expects.
-    //
-    // DeviceActivitySchedule tells iOS:
-    // "Call my monitor extension at this start time and end time."
+    // Builds the DeviceActivity schedule that iOS will monitor.
     static func schedule(for rule: Rule) -> DeviceActivitySchedule {
-        DeviceActivitySchedule(
+        // Uses a non-repeating schedule for a one-time rule.
+        if rule.isOneTime {
+            // Creates one exact calendar interval for iOS to monitor.
+            return DeviceActivitySchedule(
+                // Sets the exact start date and time.
+                intervalStart: oneTimeStartComponents(for: rule),
+                // Sets the exact end date and time.
+                intervalEnd: oneTimeEndComponents(for: rule),
+                // Tells iOS this schedule should happen only once.
+                repeats: false
+            )
+        }
+
+        // Creates a repeating daily schedule for recurring rules.
+        return DeviceActivitySchedule(
+            // Sets the daily start time.
             intervalStart: timeComponents(from: rule.startTime),
+            // Sets the daily end time.
             intervalEnd: timeComponents(from: rule.endTime),
+            // Tells iOS this schedule repeats.
             repeats: true
         )
     }
 
-    // Returns the rule duration in minutes.
+    // Calculates how many minutes the rule lasts.
     static func durationMinutes(for rule: Rule) -> Int {
+        // Converts the start time into minutes after midnight.
         let startMinutes = minutesSinceMidnight(rule.startTime)
+
+        // Converts the end time into minutes after midnight.
         let endMinutes = minutesSinceMidnight(rule.endTime)
 
+        // Handles rules that start and end on the same day.
         if startMinutes < endMinutes {
+            // Returns the same-day duration.
             return endMinutes - startMinutes
         }
 
+        // Handles rules that pass midnight.
         if startMinutes > endMinutes {
+            // Returns the overnight duration.
             return (24 * 60 - startMinutes) + endMinutes
         }
 
+        // Treats matching start and end times as zero minutes.
         return 0
     }
 
-    // Converts a Date into an Int representing minutes since midnight.
-    //
-    // Example:
-    // 1:05 AM -> 65
-    // 9:00 AM -> 540
-    // 8:42 PM -> 1242
-    private static func minutesSinceMidnight(_ date: Date) -> Int {
+    // Checks whether a one-time rule has already finished.
+    static func isCompletedOneTimeRule(_ rule: Rule, now: Date = Date()) -> Bool {
+        // Recurring rules never complete once.
+        guard rule.isOneTime else {
+            // Tells the caller this is not a completed one-time rule.
+            return false
+        }
 
-        // Pull just the hour and minute out of the Date.
-        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+        // Builds the exact one-time interval if possible.
+        guard let interval = oneTimeInterval(for: rule) else {
+            // Treats invalid one-time data as not completed here.
+            return false
+        }
 
-        // components.hour is optional because Calendar extraction can theoretically fail.
-        // ?? 0 means "use 0 if this optional is nil."
-        return (components.hour ?? 0) * 60 + (components.minute ?? 0)
+        // Returns true when now is at or after the one-time end.
+        return now >= interval.end
     }
 
-    // DeviceActivitySchedule wants DateComponents, not full Date values.
-    //
-    // That is because the schedule repeats daily, so Apple only needs hour/minute.
-    private static func timeComponents(from date: Date) -> DateComponents {
+    // Builds display text that explains how a rule repeats.
+    static func recurrenceSummary(for rule: Rule) -> String {
+        // Handles one-time rules first.
+        if rule.isOneTime {
+            // Checks whether the one-time rule has a saved date.
+            if let oneTimeDate = rule.oneTimeDate {
+                // Turns the saved date into readable text.
+                let dateText = oneTimeDate.formatted(date: .abbreviated, time: .omitted)
+                
+                // Returns one-time text with the exact date.
+                return "One time: \(dateText)"
+            }
+            
+            // Returns the one-time label.
+            return "One time"
+        }
+
+        // Checks whether every weekday is selected.
+        if rule.repeatWeekdays == Rule.allWeekdays {
+            // Returns the daily label.
+            return "Daily"
+        }
+
+        // Starts with an empty list of selected weekday labels.
+        var labels: [String] = []
+
+        // Walks through weekdays in display order.
+        for weekday in weekdayDisplayOrder {
+            // Skips weekdays this rule does not repeat on.
+            guard rule.repeatWeekdays.contains(weekday) else {
+                // Moves on to the next weekday.
+                continue
+            }
+
+            // Safely reads the short label for this weekday number.
+            guard let label = weekdayShortLabels[weekday] else {
+                // Moves on if the label dictionary is missing a value.
+                continue
+            }
+
+            // Adds the weekday label to the display list.
+            labels.append(label)
+        }
+
+        // Joins labels into text like "Mon, Wed, Fri".
+        return labels.joined(separator: ", ")
+    }
+
+    // Checks whether a one-time rule is active right now.
+    private static func isOneTimeRuleActive(_ rule: Rule, now: Date) -> Bool {
+        // Builds the exact one-time interval if possible.
+        guard let interval = oneTimeInterval(for: rule) else {
+            // Says the rule is inactive if its date data is missing.
+            return false
+        }
+
+        // Returns true only while now is inside the interval.
+        return now >= interval.start && now < interval.end
+    }
+
+    // Checks whether a recurring rule is active right now.
+    private static func isRecurringRuleActive(_ rule: Rule, now: Date) -> Bool {
+        // Converts the current time into minutes after midnight.
+        let nowMinutes = minutesSinceMidnight(now)
+
+        // Converts the rule start time into minutes after midnight.
+        let startMinutes = minutesSinceMidnight(rule.startTime)
+
+        // Converts the rule end time into minutes after midnight.
+        let endMinutes = minutesSinceMidnight(rule.endTime)
+
+        // Gets today's weekday number from the calendar.
+        let todayWeekday = Calendar.current.component(.weekday, from: now)
+
+        // Handles rules that start and end on the same day.
+        if startMinutes < endMinutes {
+            // Checks whether today is one of the selected repeat days.
+            let repeatsToday = rule.repeatWeekdays.contains(todayWeekday)
+
+            // Checks whether now is after the start time.
+            let isAfterStart = nowMinutes >= startMinutes
+
+            // Checks whether now is before the end time.
+            let isBeforeEnd = nowMinutes < endMinutes
+
+            // Returns true only when the day and time both match.
+            return repeatsToday && isAfterStart && isBeforeEnd
+        }
+
+        // Handles rules that cross midnight.
+        if startMinutes > endMinutes {
+            // Finds the weekday that came before today.
+            let previousWeekday = weekdayBefore(todayWeekday)
+
+            // Checks whether today's late-night start portion applies.
+            let isAfterStartOnSelectedDay = rule.repeatWeekdays.contains(todayWeekday) && nowMinutes >= startMinutes
+
+            // Checks whether today's early-morning portion belongs to yesterday's rule.
+            let isBeforeEndFromPreviousSelectedDay = rule.repeatWeekdays.contains(previousWeekday) && nowMinutes < endMinutes
+
+            // Returns true if either half of the overnight rule applies.
+            return isAfterStartOnSelectedDay || isBeforeEndFromPreviousSelectedDay
+        }
+
+        // Treats equal start and end times as inactive.
+        return false
+    }
+
+    // Builds the exact start and end dates for a one-time rule.
+    private static func oneTimeInterval(for rule: Rule) -> DateInterval? {
+        // Reads the chosen calendar date for this one-time rule.
+        guard let oneTimeDate = rule.oneTimeDate else {
+            // Stops if the one-time rule has no date.
+            return nil
+        }
+
+        // Pulls the hour and minute out of the saved start time.
+        let startComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.startTime)
+
+        // Pulls the hour and minute out of the saved end time.
+        let endComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.endTime)
+
+        // Combines the one-time date with the start hour and minute.
+        guard let startDate = Calendar.current.date(
+            // Sets the start hour.
+            bySettingHour: startComponents.hour ?? 0,
+            // Sets the start minute.
+            minute: startComponents.minute ?? 0,
+            // Sets seconds to zero.
+            second: 0,
+            // Uses the selected one-time date.
+            of: oneTimeDate
+        ) else {
+            // Stops if Swift cannot build the start date.
+            return nil
+        }
+
+        // Combines the one-time date with the end hour and minute.
+        guard var endDate = Calendar.current.date(
+            // Sets the end hour.
+            bySettingHour: endComponents.hour ?? 0,
+            // Sets the end minute.
+            minute: endComponents.minute ?? 0,
+            // Sets seconds to zero.
+            second: 0,
+            // Uses the selected one-time date.
+            of: oneTimeDate
+        ) else {
+            // Stops if Swift cannot build the end date.
+            return nil
+        }
+
+        // Checks whether the rule crosses midnight.
+        if endDate <= startDate {
+            // Moves the end date to the next day for overnight rules.
+            guard let nextDayEndDate = Calendar.current.date(byAdding: .day, value: 1, to: endDate) else {
+                // Stops if Swift cannot calculate the next day.
+                return nil
+            }
+
+            // Stores the corrected overnight end date.
+            endDate = nextDayEndDate
+        }
+
+        // Returns the exact one-time start and end as one interval.
+        return DateInterval(start: startDate, end: endDate)
+    }
+
+    // Builds the start DateComponents for a one-time DeviceActivity schedule.
+    private static func oneTimeStartComponents(for rule: Rule) -> DateComponents {
+        // Builds the exact one-time interval if possible.
+        guard let interval = oneTimeInterval(for: rule) else {
+            // Falls back to time-only components if the interval is missing.
+            return timeComponents(from: rule.startTime)
+        }
+
+        // Returns full date and time pieces for the start.
+        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: interval.start)
+    }
+
+    // Builds the end DateComponents for a one-time DeviceActivity schedule.
+    private static func oneTimeEndComponents(for rule: Rule) -> DateComponents {
+        // Builds the exact one-time interval if possible.
+        guard let interval = oneTimeInterval(for: rule) else {
+            // Falls back to time-only components if the interval is missing.
+            return timeComponents(from: rule.endTime)
+        }
+
+        // Returns full date and time pieces for the end.
+        return Calendar.current.dateComponents([.year, .month, .day, .hour, .minute], from: interval.end)
+    }
+
+    // Finds the weekday number before the given weekday.
+    private static func weekdayBefore(_ weekday: Int) -> Int {
+        // Checks whether the current weekday is Sunday.
+        if weekday == 1 {
+            // Returns Saturday as the day before Sunday.
+            return 7
+        }
+
+        // Returns the previous weekday number.
+        return weekday - 1
+    }
+
+    // Converts a Date into minutes after midnight.
+    private static func minutesSinceMidnight(_ date: Date) -> Int {
+        // Pulls the hour and minute out of the Date.
         let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+
+        // Converts the hour into minutes.
+        let hourMinutes = (components.hour ?? 0) * 60
+
+        // Reads the minute value, or zero if it is missing.
+        let minuteValue = components.minute ?? 0
+
+        // Returns the total minutes after midnight.
+        return hourMinutes + minuteValue
+    }
+
+    // Converts a Date into hour and minute components.
+    private static func timeComponents(from date: Date) -> DateComponents {
+        // Pulls the hour and minute out of the Date.
+        let components = Calendar.current.dateComponents([.hour, .minute], from: date)
+
+        // Builds the smaller DateComponents value DeviceActivity expects.
         return DateComponents(hour: components.hour, minute: components.minute)
     }
 }
 
-// This extends Apple's DeviceActivityName type with Focus Lock-specific helpers.
-//
-// An extension lets us add convenience behavior to a type we did not create.
+// Adds Focus Lock helpers to Apple's DeviceActivityName type.
 extension DeviceActivityName {
-
-    // Prefix all of our monitor names so we can recognize them later.
-    //
-    // Example full value:
-    // focus-lock-rule-0D0E0B8B-8D6B-4C8E-9C19-...
+    // Stores the prefix used for every Focus Lock activity name.
     private static let focusLockRulePrefix = "focus-lock-rule-"
 
-    // Custom initializer.
-    //
-    // It lets us write:
-    // DeviceActivityName(ruleID: rule.id)
-    //
-    // instead of manually building the string everywhere.
+    // Builds a DeviceActivityName from a rule id.
     init(ruleID: UUID) {
+        // Combines our prefix with the rule's unique id.
         self.init(Self.focusLockRulePrefix + ruleID.uuidString)
     }
 
-    // Computed property that tells us whether this DeviceActivityName belongs to Focus Lock.
-    //
-    // rawValue is the underlying string inside DeviceActivityName.
+    // Checks whether this activity name belongs to Focus Lock.
     var isFocusLockRuleActivity: Bool {
+        // Returns true when the raw string starts with our prefix.
         rawValue.hasPrefix(Self.focusLockRulePrefix)
+    }
+
+    // Pulls the original rule id back out of the activity name.
+    var focusLockRuleID: UUID? {
+        // Stops if this is not one of our Focus Lock activity names.
+        guard isFocusLockRuleActivity else {
+            // Returns nothing because this name does not belong to a rule.
+            return nil
+        }
+
+        // Removes the Focus Lock prefix and leaves only the UUID text.
+        let idString = rawValue.replacingOccurrences(of: Self.focusLockRulePrefix, with: "")
+
+        // Converts the UUID text back into a UUID value.
+        return UUID(uuidString: idString)
     }
 }

--- a/focus-lock/Shared/Rule.swift
+++ b/focus-lock/Shared/Rule.swift
@@ -51,6 +51,34 @@ struct Rule: Identifiable, Hashable, Codable {
     // We mostly use activitySelection.applicationTokens right now.
     // An ApplicationToken is Apple's privacy-preserving way to represent a selected app.
     var activitySelection: FamilyActivitySelection = FamilyActivitySelection()
+    
+    // Stores which weekdays this rule repeats on.
+        // Swift Calendar weekday numbers are usually:
+        // 1 = Sunday, 2 = Monday, 3 = Tuesday, 4 = Wednesday,
+        // 5 = Thursday, 6 = Friday, 7 = Saturday.
+        // If this set is empty, we treat the rule as a one-time rule.
+        var repeatWeekdays: Set<Int> = Rule.allWeekdays
+
+        // Stores the calendar date for a one-time rule.
+        // This is only used when repeatWeekdays is empty.
+        // Example: May 13, 2026.
+        var oneTimeDate: Date?
+
+        // Gives us one shared definition of "every day."
+        // Existing rules should behave like this after the migration.
+        static let allWeekdays: Set<Int> = [1, 2, 3, 4, 5, 6, 7]
+
+        // Returns true when the rule should repeat on one or more weekdays.
+        var isRecurring: Bool {
+            !repeatWeekdays.isEmpty
+        }
+
+        // Returns true when the rule should run once and then be removed.
+        var isOneTime: Bool {
+            repeatWeekdays.isEmpty
+        }
+    
+    
 
     // Hashable usually implies Equatable, and Swift can often generate this for us.
     // We define it manually so two Rule values count as "the same rule" if their IDs match.

--- a/focus-lock/focus-lock/ContentView.swift
+++ b/focus-lock/focus-lock/ContentView.swift
@@ -10,9 +10,8 @@ import SwiftUI
 struct ContentView: View {
     @State private var isAuthed = false
     
-    // Create and own the shared app state at the root.
-    // @StateObject ensures the object is created once and survives view reloads.
-    @StateObject private var appState = AppState()
+    // Reads the shared app state created by focus_lockApp.
+    @EnvironmentObject private var appState: AppState
 
     var body: some View {
         if isAuthed {
@@ -46,4 +45,6 @@ struct ContentView: View {
 
 #Preview {
     ContentView()
+        // Gives the preview the shared app state that ContentView expects.
+        .environmentObject(AppState())
 }

--- a/focus-lock/focus-lock/DeviceActivityScheduleManager.swift
+++ b/focus-lock/focus-lock/DeviceActivityScheduleManager.swift
@@ -3,99 +3,102 @@
 //  focus-lock
 //
 
-// DeviceActivity gives us DeviceActivityCenter.
-// The center is the object the main app uses to register schedules with iOS.
+// Imports Apple's DeviceActivity scheduling tools.
 import DeviceActivity
 
-// FamilyControls defines FamilyActivitySelection.applicationTokens.
-// This file reads rule.activitySelection.applicationTokens for diagnostics.
+// Imports Apple's Screen Time picker types.
 import FamilyControls
 
-// Foundation gives us Set, Array, print, etc.
+// Imports basic Swift types like Set, Array, and Calendar.
 import Foundation
 
-// This class belongs to the main app target.
-//
-// Its job is NOT to block apps directly.
-// Its job is to tell iOS:
-// "Please wake my DeviceActivity monitor extension at these rule start/end times."
+// Creates one object responsible for registering rule schedules with iOS.
 final class DeviceActivityScheduleManager {
 
-    // Singleton pattern.
-    //
-    // This gives the app one shared schedule manager:
-    // DeviceActivityScheduleManager.shared
+    // Creates one shared schedule manager for the whole app.
     static let shared = DeviceActivityScheduleManager()
 
-    // DeviceActivityCenter is Apple's schedule registration object.
+    // Creates Apple's schedule registration center.
     private let center = DeviceActivityCenter()
 
-    // Make iOS's registered schedules match our current rules array.
-    //
-    // We call this after adding, toggling, deleting, and loading rules.
+    // Makes iOS's registered schedules match the app's saved rules.
     func syncSchedules(for rules: [Rule]) {
+        // Records how many total rules were sent into schedule sync.
         FocusLockDiagnostics.record("ScheduleManager sync requested with \(rules.count) total rule(s).")
 
-        // Keep only rules that should actually be monitored.
-        let monitorableRules = rules.filter(FocusLockSchedule.isMonitorable)
+        // Keeps only rules that are enabled, valid, long enough, and not completed.
+        let monitorableRules = rules.filter { FocusLockSchedule.isMonitorable($0) }
+
+        // Records how many rules can actually be monitored.
         FocusLockDiagnostics.record("ScheduleManager found \(monitorableRules.count) monitorable rule(s).")
 
+        // Looks at every rule that cannot currently be monitored.
         for rule in rules where !FocusLockSchedule.isMonitorable(rule) {
+            // Records why this rule may have been skipped.
             FocusLockDiagnostics.record(
-                "ScheduleManager skipping rule \(rule.id): enabled=\(rule.isEnabled), selectedApps=\(rule.activitySelection.applicationTokens.count), durationMinutes=\(FocusLockSchedule.durationMinutes(for: rule)), minimumDurationMinutes=\(FocusLockSchedule.minimumMonitorDurationMinutes)."
+                "ScheduleManager skipping rule \(rule.id): enabled=\(rule.isEnabled), selectedApps=\(rule.activitySelection.applicationTokens.count), durationMinutes=\(FocusLockSchedule.durationMinutes(for: rule)), minimumDurationMinutes=\(FocusLockSchedule.minimumMonitorDurationMinutes), recurrence=\(FocusLockSchedule.recurrenceSummary(for: rule))."
             )
         }
 
-        // Convert each rule into the DeviceActivityName we expect iOS to know about.
-        //
-        // map transforms [Rule] into [DeviceActivityName].
-        // Set(...) turns it into a unique collection.
+        // Builds the set of DeviceActivity names iOS should currently monitor.
         let expectedActivities = Set(monitorableRules.map { DeviceActivityName(ruleID: $0.id) })
 
-        // center.activities is what iOS is currently monitoring for this app.
-        //
-        // We filter down to only the activities created by Focus Lock.
-        // \.isFocusLockRuleActivity is Swift key-path shorthand for:
-        // { activity in activity.isFocusLockRuleActivity }
+        // Reads the set of Focus Lock activities iOS is already monitoring.
         let existingFocusLockActivities = Set(center.activities.filter(\.isFocusLockRuleActivity))
 
-        // Anything existing in iOS but no longer expected by our rules should be removed.
-        //
-        // Example:
-        // User deletes a rule.
-        // We need to stop monitoring that old rule's schedule.
+        // Finds old iOS schedules that no longer match saved monitorable rules.
         let obsoleteActivities = existingFocusLockActivities.subtracting(expectedActivities)
+
+        // Records the activities iOS is currently monitoring.
         FocusLockDiagnostics.record("ScheduleManager existing activities: \(existingFocusLockActivities.map(\.rawValue).sorted()).")
+
+        // Records the activities Focus Lock expects iOS to monitor.
         FocusLockDiagnostics.record("ScheduleManager expected activities: \(expectedActivities.map(\.rawValue).sorted()).")
 
-        // If there are obsolete activities, ask iOS to stop monitoring them.
+        // Checks whether there are old schedules to remove.
         if !obsoleteActivities.isEmpty {
+            // Records which old schedules are being stopped.
             FocusLockDiagnostics.record("ScheduleManager stopping obsolete activities: \(obsoleteActivities.map(\.rawValue).sorted()).")
+
+            // Tells iOS to stop monitoring schedules for deleted, disabled, invalid, or completed rules.
             center.stopMonitoring(Array(obsoleteActivities))
         }
 
-        // Register or update every current monitorable rule.
+        // Registers or updates every rule that should be monitored.
         for rule in monitorableRules {
+            // Pulls the start hour and minute from the rule.
             let startComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.startTime)
+
+            // Pulls the end hour and minute from the rule.
             let endComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.endTime)
+
+            // Builds the unique DeviceActivity name for this rule.
             let activityName = DeviceActivityName(ruleID: rule.id)
 
+            // Records the schedule registration details for debugging.
             FocusLockDiagnostics.record(
-                "ScheduleManager registering rule \(rule.id) as \(activityName.rawValue), start=\(startComponents.hour ?? -1):\(startComponents.minute ?? -1), end=\(endComponents.hour ?? -1):\(endComponents.minute ?? -1), selectedApps=\(rule.activitySelection.applicationTokens.count)."
+                "ScheduleManager registering rule \(rule.id) as \(activityName.rawValue), start=\(startComponents.hour ?? -1):\(startComponents.minute ?? -1), end=\(endComponents.hour ?? -1):\(endComponents.minute ?? -1), selectedApps=\(rule.activitySelection.applicationTokens.count), recurrence=\(FocusLockSchedule.recurrenceSummary(for: rule))."
             )
 
-            // startMonitoring can throw an error, so it must be called with try.
+            // Starts a block that can catch schedule registration errors.
             do {
+                // Tells iOS to monitor this rule's schedule.
                 try center.startMonitoring(
+                    // Passes the unique name for this rule's schedule.
                     activityName,
+                    // Passes either a repeating or one-time schedule.
                     during: FocusLockSchedule.schedule(for: rule)
                 )
+
+                // Records that iOS accepted the schedule.
                 FocusLockDiagnostics.record("ScheduleManager successfully registered \(activityName.rawValue).")
             } catch {
+                // Records that iOS rejected or failed to register the schedule.
                 FocusLockDiagnostics.record("ScheduleManager failed to register \(activityName.rawValue): \(error)")
             }
         }
 
+        // Records all Focus Lock activities after schedule sync finishes.
         FocusLockDiagnostics.record("ScheduleManager center activities after sync: \(center.activities.map(\.rawValue).sorted()).")
     }
 }

--- a/focus-lock/focus-lock/State/AppState.swift
+++ b/focus-lock/focus-lock/State/AppState.swift
@@ -28,13 +28,27 @@ final class AppState: ObservableObject {
     
     // Encapsulation: The View shouldn't know HOW to append a rule, just that it WANTS to add one.
     // We now include start and end times in the creation.
-    func addRule(title: String, start: Date, end: Date, activitySelection: FamilyActivitySelection){
+    func addRule(title: String,
+                 start: Date,
+                 end: Date,
+                 activitySelection: FamilyActivitySelection,
+                 // Stores the selected repeat days for this new rule.
+                 repeatWeekdays: Set<Int> = Rule.allWeekdays,
+                 // Stores the date for this rule when it is a one-time rule.
+                 oneTimeDate: Date? = nil){
+        // Clears the one-time date for recurring rules because recurring rules do not need one exact date.
+        let savedOneTimeDate = repeatWeekdays.isEmpty ? oneTimeDate : nil
+        
         let newRule = Rule(
             title: title,
             isEnabled: true,
             startTime: start,
             endTime: end,
-            activitySelection: activitySelection
+            activitySelection: activitySelection,
+            // Saves the repeat days chosen by the user.
+            repeatWeekdays: repeatWeekdays,
+            // Saves the one-time date only when this is a one-time rule.
+            oneTimeDate: savedOneTimeDate
         )
         rules.append(newRule)
         // Note: saving, schedule registration, and shield refresh happen automatically
@@ -87,8 +101,20 @@ final class AppState: ObservableObject {
     
     // Loads rules from the file path (Only runs at init)
     private func loadRules() -> [Rule] {
+        // Reads all saved rules from App Group storage.
+        let savedRules = FocusLockRuleStore.loadRules()
         
-        FocusLockRuleStore.loadRules()
+        // Removes one-time rules that have already completed.
+        let activeRules = savedRules.filter { !FocusLockSchedule.isCompletedOneTimeRule($0) }
+        
+        // Checks whether any completed one-time rules were removed.
+        if activeRules.count != savedRules.count {
+            // Saves the cleaned rule list back to App Group storage.
+            FocusLockRuleStore.saveRules(activeRules)
+        }
+        
+        // Gives callers the cleaned list of rules.
+        return activeRules
     }
     
     func deleteRule(id:UUID){
@@ -99,16 +125,29 @@ final class AppState: ObservableObject {
         // didSet re-applies schedules and shields using only the rules that still exist.
     }
     
+    // Reloads rules from shared App Group storage.
+    func refreshRulesFromStorage() {
+        // Reads the latest saved rules, including changes made by the DeviceActivity extension.
+        rules = loadRules()
+    }
+    
     func editRule(id: UUID,
                   title: String,
                   start: Date,
                   end: Date,
-                  activitySelection: FamilyActivitySelection
+                  activitySelection: FamilyActivitySelection,
+                  // Stores the updated repeat days for this rule.
+                  repeatWeekdays: Set<Int> = Rule.allWeekdays,
+                  // Stores the updated date when this rule is one-time.
+                  oneTimeDate: Date? = nil
               ){
         // Finds the position of the rule in the rules array whose id matches the id passed into this function.
         guard let index = rules.firstIndex(where: {$0.id == id}) else{
             return
         }
+        
+        // Clears the one-time date for recurring rules because recurring rules do not need one exact date.
+        let savedOneTimeDate = repeatWeekdays.isEmpty ? oneTimeDate : nil
         
         // Replace the old title with the new title from the edit form.
             rules[index].title = title
@@ -121,6 +160,12 @@ final class AppState: ObservableObject {
 
             // Replace the old Screen Time app/category selection with the new selection from the edit form.
             rules[index].activitySelection = activitySelection
+        
+            // Replace the old repeat days with the new repeat days from the edit form.
+            rules[index].repeatWeekdays = repeatWeekdays
+        
+            // Replace the old one-time date with the new one-time date from the edit form.
+            rules[index].oneTimeDate = savedOneTimeDate
 
             // Because rules is @Published and has didSet, changing this rule automatically saves and syncs it.
         

--- a/focus-lock/focus-lock/Views/CreateRuleView.swift
+++ b/focus-lock/focus-lock/Views/CreateRuleView.swift
@@ -15,11 +15,19 @@ struct CreateRuleView: View {
     @State private var ruleName = ""
     @State private var startTime = Calendar.current.date(from: .init(hour: 9, minute: 0))!
     @State private var endTime = Calendar.current.date(from: .init(hour: 17, minute: 0))!
+    // Stores the weekdays selected for repeating this rule.
+    @State private var repeatWeekdays = Rule.allWeekdays
+    // Stores the calendar date used when no repeat weekdays are selected.
+    @State private var oneTimeDate = Date()
 
     @State private var activitySelection = FamilyActivitySelection()
     @State private var showAppPicker = false
+    // Controls the sheet where the user chooses repeat settings.
+    @State private var showRepeatSettings = false
     // Controls the popup shown when the selected schedule is too short for DeviceActivity.
     @State private var showDurationAlert = false
+    // Controls the popup shown when a one-time rule already ended.
+    @State private var showCompletedOneTimeAlert = false
     
     // Builds the text shown next to the app picker row.
     private var selectedActivitySummary: String {
@@ -58,6 +66,12 @@ struct CreateRuleView: View {
         // Joins the non-empty pieces and adds the selected label at the end.
         return parts.joined(separator: ", ") + " selected"
     }
+    
+    // Returns true when no repeat weekdays are selected.
+    private var isOneTimeRule: Bool {
+        // Empty repeat days means this rule should happen once.
+        repeatWeekdays.isEmpty
+    }
 
 
 
@@ -72,6 +86,33 @@ struct CreateRuleView: View {
                     DatePicker("Start Time", selection: $startTime, displayedComponents: .hourAndMinute)
 
                     DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
+                    
+                    // Shows a date picker only when the rule is one-time.
+                    if isOneTimeRule {
+                        // Lets the user choose the exact date for the one-time rule.
+                        DatePicker("Date", selection: $oneTimeDate, displayedComponents: .date)
+                    }
+                }
+                
+                // Lets the user open repeat settings from one clean row.
+                Section("Repeat") {
+                    // Opens the repeat settings sheet when tapped.
+                    Button {
+                        // Shows the repeat settings sheet.
+                        showRepeatSettings = true
+                    } label: {
+                        // Places the row title and current repeat summary side by side.
+                        HStack {
+                            // Shows the row title.
+                            Text("Repeat")
+                            // Pushes the summary to the right side.
+                            Spacer()
+                            // Shows the current recurrence choice.
+                            Text(repeatSummary)
+                                // Styles the summary as secondary text.
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
 
                 Section("Apps") {
@@ -106,7 +147,11 @@ struct CreateRuleView: View {
                                 isEnabled: true,
                                 startTime: startTime,
                                 endTime: endTime,
-                                activitySelection: activitySelection
+                                activitySelection: activitySelection,
+                                // Stores the selected repeat weekdays on the draft rule.
+                                repeatWeekdays: repeatWeekdays,
+                                // Stores a date only when this is a one-time rule.
+                                oneTimeDate: isOneTimeRule ? oneTimeDate : nil
                             )
                         
                         // DeviceActivity will not monitor intervals shorter than our shared
@@ -116,11 +161,23 @@ struct CreateRuleView: View {
                             return
                         }
                         
+                        // One-time rules should not be saved if their end time has already passed.
+                        if FocusLockSchedule.isCompletedOneTimeRule(draftRule) {
+                            // Shows an alert explaining that the selected one-time session is already over.
+                            showCompletedOneTimeAlert = true
+                            // Stops before saving the expired one-time rule.
+                            return
+                        }
+                        
                         appState.addRule(
                             title: ruleName,
                             start: startTime,
                             end: endTime,
-                            activitySelection: activitySelection
+                            activitySelection: activitySelection,
+                            // Sends the selected repeat weekdays to AppState.
+                            repeatWeekdays: repeatWeekdays,
+                            // Sends a one-time date only when no weekdays are selected.
+                            oneTimeDate: isOneTimeRule ? oneTimeDate : nil
                         )
 
                         dismiss()
@@ -134,10 +191,140 @@ struct CreateRuleView: View {
             } message: {
                 Text("Focus Lock rules must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes long.")
             }
+            // Explains why Save did not work when a one-time rule is already over.
+            .alert("Invalid Time Range", isPresented: $showCompletedOneTimeAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Choose a future date or a time window that has not already ended.")
+            }
+            // Opens the repeat settings picker as a sheet.
+            .sheet(isPresented: $showRepeatSettings) {
+                // Shows the shared repeat settings UI.
+                RepeatSettingsView(repeatWeekdays: $repeatWeekdays)
+            }
             .familyActivityPicker(
                 isPresented: $showAppPicker,
                 selection: $activitySelection
             )
+        }
+    }
+    
+    // Builds the repeat summary shown on the main form.
+    private var repeatSummary: String {
+        // Creates a temporary rule so we can reuse the shared summary helper.
+        let draftRule = Rule(
+            title: ruleName,
+            isEnabled: true,
+            startTime: startTime,
+            endTime: endTime,
+            activitySelection: activitySelection,
+            repeatWeekdays: repeatWeekdays,
+            oneTimeDate: isOneTimeRule ? oneTimeDate : nil
+        )
+        
+        // Returns text like Daily, Tue/Thu, or One time.
+        return FocusLockSchedule.recurrenceSummary(for: draftRule)
+    }
+}
+
+// Reusable sheet for choosing repeat behavior.
+struct RepeatSettingsView: View {
+    // Closes this sheet when the user taps Done.
+    @Environment(\.dismiss) private var dismiss
+    
+    // Reads and writes the selected repeat weekdays from the parent screen.
+    @Binding var repeatWeekdays: Set<Int>
+    
+    // Builds the repeat settings screen.
+    var body: some View {
+        // Gives the sheet a title and toolbar.
+        NavigationStack {
+            // Creates an iOS-style settings form.
+            Form {
+                // Groups the simple repeat choices.
+                Section("Repeat") {
+                    // Selects a one-time rule.
+                    Button {
+                        // Empty repeat days means this rule does not repeat.
+                        repeatWeekdays = []
+                    } label: {
+                        // Shows the one-time option row.
+                        repeatOptionRow(title: "Does Not Repeat", isSelected: repeatWeekdays.isEmpty)
+                    }
+                    
+                    // Selects a daily recurring rule.
+                    Button {
+                        // All weekdays means this rule repeats every day.
+                        repeatWeekdays = Rule.allWeekdays
+                    } label: {
+                        // Shows the daily option row.
+                        repeatOptionRow(title: "Daily", isSelected: repeatWeekdays == Rule.allWeekdays)
+                    }
+                }
+                
+                // Groups custom weekday choices.
+                Section("Custom Days") {
+                    // Creates one tappable row for each weekday.
+                    ForEach(FocusLockSchedule.weekdayDisplayOrder, id: \.self) { weekday in
+                        // Toggles this weekday when the row is tapped.
+                        Button {
+                            // Adds or removes the selected weekday.
+                            toggleRepeatWeekday(weekday)
+                        } label: {
+                            // Shows the weekday row with a checkmark when selected.
+                            repeatOptionRow(
+                                title: FocusLockSchedule.weekdayShortLabels[weekday] ?? "",
+                                isSelected: repeatWeekdays.contains(weekday)
+                            )
+                        }
+                    }
+                }
+            }
+            // Shows the sheet title.
+            .navigationTitle("Repeat")
+            // Uses an inline title so the sheet feels compact.
+            .navigationBarTitleDisplayMode(.inline)
+            // Adds buttons to the top of the sheet.
+            .toolbar {
+                // Places Done on the confirmation side of the toolbar.
+                ToolbarItem(placement: .confirmationAction) {
+                    // Creates the Done button.
+                    Button("Done") {
+                        // Closes the sheet.
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+    
+    // Builds one selectable option row.
+    private func repeatOptionRow(title: String, isSelected: Bool) -> some View {
+        // Places the label and checkmark in one row.
+        HStack {
+            // Shows the option title.
+            Text(title)
+            // Pushes the checkmark to the right side.
+            Spacer()
+            // Shows a checkmark only for the selected option.
+            if isSelected {
+                // Displays Apple's checkmark icon.
+                Image(systemName: "checkmark")
+                    // Uses the app accent color for selected rows.
+                    .foregroundColor(.accentColor)
+            }
+        }
+    }
+    
+    // Adds or removes one weekday from the selected repeat days.
+    private func toggleRepeatWeekday(_ weekday: Int) {
+        // Checks whether the weekday is already selected.
+        if repeatWeekdays.contains(weekday) {
+            // Removes the weekday when it is already selected.
+            repeatWeekdays.remove(weekday)
+        } else {
+            // Adds the weekday when it is not selected yet.
+            repeatWeekdays.insert(weekday)
         }
     }
 }

--- a/focus-lock/focus-lock/Views/EditRuleView.swift
+++ b/focus-lock/focus-lock/Views/EditRuleView.swift
@@ -31,12 +31,24 @@ struct EditRuleView: View {
 
     // Stores the editable app/category selection.
     @State private var activitySelection: FamilyActivitySelection
+    
+    // Stores the editable repeat weekdays.
+    @State private var repeatWeekdays: Set<Int>
+    
+    // Stores the editable date for a one-time rule.
+    @State private var oneTimeDate: Date
 
     // Tracks whether Apple's Screen Time picker should be visible.
     @State private var showAppPicker = false
     
+    // Controls the sheet where the user chooses repeat settings.
+    @State private var showRepeatSettings = false
+    
     // Controls the popup shown when the edited schedule is too short for DeviceActivity.
     @State private var showDurationAlert = false
+    
+    // Controls the popup shown when a one-time rule already ended.
+    @State private var showCompletedOneTimeAlert = false
     
     // Builds the text shown next to the app picker row.
     private var selectedActivitySummary: String {
@@ -75,6 +87,12 @@ struct EditRuleView: View {
         // Joins the non-empty pieces and adds the selected label at the end.
         return parts.joined(separator: ", ") + " selected"
     }
+    
+    // Returns true when no repeat weekdays are selected.
+    private var isOneTimeRule: Bool {
+        // Empty repeat days means this rule should happen once.
+        repeatWeekdays.isEmpty
+    }
 
 
 
@@ -94,6 +112,12 @@ struct EditRuleView: View {
 
         // Fills the app picker with the rule's current selected apps.
         _activitySelection = State(initialValue: rule.activitySelection)
+        
+        // Fills the repeat weekday controls with the rule's current repeat days.
+        _repeatWeekdays = State(initialValue: rule.repeatWeekdays)
+        
+        // Fills the one-time date picker with the saved date, or today if there is no saved date yet.
+        _oneTimeDate = State(initialValue: rule.oneTimeDate ?? Date())
     }
 
     // Describes the UI that appears inside the edit sheet.
@@ -115,6 +139,33 @@ struct EditRuleView: View {
 
                     // Lets the user change the end time.
                     DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
+                    
+                    // Shows a date picker only when the edited rule is one-time.
+                    if isOneTimeRule {
+                        // Lets the user choose the exact date for the one-time rule.
+                        DatePicker("Date", selection: $oneTimeDate, displayedComponents: .date)
+                    }
+                }
+                
+                // Groups recurrence controls under a Repeat heading.
+                Section("Repeat") {
+                    // Opens the repeat settings sheet when tapped.
+                    Button {
+                        // Shows the repeat settings sheet.
+                        showRepeatSettings = true
+                    } label: {
+                        // Places the row title and current repeat summary side by side.
+                        HStack {
+                            // Shows the row title.
+                            Text("Repeat")
+                            // Pushes the summary to the right side.
+                            Spacer()
+                            // Shows the current recurrence choice.
+                            Text(repeatSummary)
+                                // Styles the summary as secondary text.
+                                .foregroundStyle(.secondary)
+                        }
+                    }
                 }
 
                 // Groups the selected app controls under an Apps heading.
@@ -167,7 +218,11 @@ struct EditRuleView: View {
                             createdAt: rule.createdAt,
                             startTime: startTime,
                             endTime: endTime,
-                            activitySelection: activitySelection
+                            activitySelection: activitySelection,
+                            // Stores the edited repeat weekdays on the draft rule.
+                            repeatWeekdays: repeatWeekdays,
+                            // Stores a date only when this is a one-time rule.
+                            oneTimeDate: isOneTimeRule ? oneTimeDate : nil
                         )
 
                         // DeviceActivity will not monitor intervals shorter than our shared
@@ -176,13 +231,25 @@ struct EditRuleView: View {
                             showDurationAlert = true
                             return
                         }
+                        
+                        // One-time rules should not be saved if their end time has already passed.
+                        if FocusLockSchedule.isCompletedOneTimeRule(draftRule) {
+                            // Shows an alert explaining that the selected one-time session is already over.
+                            showCompletedOneTimeAlert = true
+                            // Stops before saving the expired one-time rule.
+                            return
+                        }
 
                         appState.editRule(
                             id: rule.id,
                             title: ruleName,
                             start: startTime,
                             end: endTime,
-                            activitySelection: activitySelection
+                            activitySelection: activitySelection,
+                            // Sends the edited repeat weekdays to AppState.
+                            repeatWeekdays: repeatWeekdays,
+                            // Sends a one-time date only when no weekdays are selected.
+                            oneTimeDate: isOneTimeRule ? oneTimeDate : nil
                         )
 
                         dismiss()
@@ -199,6 +266,17 @@ struct EditRuleView: View {
             } message: {
                 Text("Focus Lock rules must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes long.")
             }
+            // Explains why Save did not work when a one-time rule is already over.
+            .alert("Invalid Time Range", isPresented: $showCompletedOneTimeAlert) {
+                Button("OK", role: .cancel) {}
+            } message: {
+                Text("Choose a future date or a time window that has not already ended.")
+            }
+            // Opens the repeat settings picker as a sheet.
+            .sheet(isPresented: $showRepeatSettings) {
+                // Shows the shared repeat settings UI.
+                RepeatSettingsView(repeatWeekdays: $repeatWeekdays)
+            }
             // Attaches Apple's Screen Time picker to this edit screen.
             .familyActivityPicker(
                 // Opens the picker when showAppPicker becomes true.
@@ -208,5 +286,24 @@ struct EditRuleView: View {
                 selection: $activitySelection
             )
         }
+    }
+    
+    // Builds the repeat summary shown on the main form.
+    private var repeatSummary: String {
+        // Creates a temporary rule so we can reuse the shared summary helper.
+        let draftRule = Rule(
+            id: rule.id,
+            title: ruleName,
+            isEnabled: rule.isEnabled,
+            createdAt: rule.createdAt,
+            startTime: startTime,
+            endTime: endTime,
+            activitySelection: activitySelection,
+            repeatWeekdays: repeatWeekdays,
+            oneTimeDate: isOneTimeRule ? oneTimeDate : nil
+        )
+        
+        // Returns text like Daily, Tue/Thu, or One time.
+        return FocusLockSchedule.recurrenceSummary(for: draftRule)
     }
 }

--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -125,6 +125,11 @@ struct RulesView: View {
                                 .font(.subheadline)
                                 .foregroundStyle(.gray)
                             
+                            // Shows whether this rule is daily, one-time, or repeats on selected weekdays.
+                            Text(FocusLockSchedule.recurrenceSummary(for: rule))
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                            
                             
                             // Shows how many picker items this rule contains.
                             Text(selectedActivitySummary(for: rule))

--- a/focus-lock/focus-lock/focus_lockApp.swift
+++ b/focus-lock/focus-lock/focus_lockApp.swift
@@ -12,13 +12,31 @@ struct focus_lockApp: App {
     
     // 1. Create the state object
     @StateObject var familyControlsManager = FamilyControlsManager.shared
+    // Creates the shared app state at the app entry point.
+    @StateObject private var appState = AppState()
+    // Watches whether the app is active, inactive, or in the background.
+    @Environment(\.scenePhase) private var scenePhase
+    
     var body: some Scene {
         WindowGroup {
             ContentView()
+                // Gives every child screen access to the same shared app state.
+                .environmentObject(appState)
             
             // 2. Start the check when the app launches
                 .task {
                     await familyControlsManager.requestAuthorization()
+                }
+                // Runs whenever the app changes between active, inactive, and background.
+                .onChange(of: scenePhase) { newPhase in
+                    // Only reload saved rules when the app becomes active on screen.
+                    guard newPhase == .active else {
+                        // Ignore background and inactive transitions.
+                        return
+                    }
+                    
+                    // Reload rules in case the DeviceActivity extension deleted a completed one-time rule.
+                    appState.refreshRulesFromStorage()
                 }
             
         }


### PR DESCRIPTION
## Summary

This PR adds recurrence support for Focus Lock rules.

Users can now create rules that either:

- repeat daily
- repeat on selected custom days
- do not repeat and delete themselves after completing once

The main idea is:

- recurring rules save selected weekdays
- one-time rules save an exact date
- when a one-time rule ends, the DeviceActivity extension removes it from shared storage
- overlapping rules still work because shields are recalculated from all remaining active rules

## Files Changed

### `Shared/Rule.swift`

This file defines the saved `Rule` model.

Added:

```swift
var repeatWeekdays: Set<Int> = Rule.allWeekdays
var oneTimeDate: Date?
```

What this does:

- `repeatWeekdays` stores which days a rule repeats on.
- `oneTimeDate` stores the exact calendar date for a one-time rule.
- If `repeatWeekdays` is empty, the rule is treated as one-time.
- If `repeatWeekdays` has values, the rule is recurring.

Added:

```swift
static let allWeekdays: Set<Int> = [1, 2, 3, 4, 5, 6, 7]
```

This gives the app one shared definition of “every day.”

Swift weekday numbers are:

```text
1 = Sunday
2 = Monday
3 = Tuesday
4 = Wednesday
5 = Thursday
6 = Friday
7 = Saturday
```

Added:

```swift
var isRecurring: Bool {
    !repeatWeekdays.isEmpty
}

var isOneTime: Bool {
    repeatWeekdays.isEmpty
}
```

These are helper properties.

They let the rest of the code ask simple questions:

```text
Is this rule recurring?
Is this rule one-time?
```

Instead of repeating this logic everywhere:

```swift
repeatWeekdays.isEmpty
```

Result:

The app can now save both recurring and one-time rules in the same `Rule` model.

---

### `Shared/FocusLockSchedule.swift`

This file is the shared schedule “brain” used by both the main app and the DeviceActivity extension.

Added weekday constants:

```swift
static let weekdayDisplayOrder = [1, 2, 3, 4, 5, 6, 7]

static let weekdayShortLabels: [Int: String] = [
    1: "Sun",
    2: "Mon",
    3: "Tue",
    4: "Wed",
    5: "Thu",
    6: "Fri",
    7: "Sat"
]
```

What this does:

- Gives the UI a consistent order for weekdays.
- Gives the app short labels to show in summaries and repeat settings.

Updated:

```swift
static func isMonitorable(_ rule: Rule, now: Date = Date()) -> Bool
```

This method decides whether a rule should be registered with `DeviceActivity`.

It now checks:

- the rule is enabled
- the rule has selected apps/categories/websites
- the rule duration is at least 15 minutes
- the recurrence settings are valid
- a one-time rule has not already completed

Added:

```swift
static func hasValidRecurrence(_ rule: Rule) -> Bool
```

What this does:

- recurring rules are valid if they have repeat weekdays
- one-time rules are valid if they have a `oneTimeDate`

Added one-time schedule logic:

```swift
if rule.isOneTime {
    return DeviceActivitySchedule(
        intervalStart: oneTimeStartComponents(for: rule),
        intervalEnd: oneTimeEndComponents(for: rule),
        repeats: false
    )
}
```

What this does:

- one-time rules use full date and time components
- `repeats: false` tells iOS to run the schedule only once

Recurring rules still use:

```swift
repeats: true
```

Result:

Daily/custom recurring rules keep repeating. One-time rules only run once.

Added:

```swift
static func isCompletedOneTimeRule(_ rule: Rule, now: Date = Date()) -> Bool
```

What this does:

- returns `true` when a one-time rule’s end date/time has passed
- used to prevent saving expired one-time rules
- used to clean old one-time rules from storage
- used by the extension before deleting a completed one-time rule

Added:

```swift
private static func oneTimeInterval(for rule: Rule) -> DateInterval?
```

What this does:

- combines `oneTimeDate`, `startTime`, and `endTime`
- creates one exact start/end interval

Example:

```text
Date: May 13, 2026
Start: 11:00 PM
End: 2:00 AM
```

Becomes:

```text
May 13, 2026 11:00 PM -> May 14, 2026 2:00 AM
```

This is what makes overnight one-time rules work.

Updated recurring active logic:

```swift
private static func isRecurringRuleActive(_ rule: Rule, now: Date) -> Bool
```

What this does:

- checks today’s weekday
- checks whether the current time is inside the rule window
- handles overnight recurring rules by checking the previous weekday

Example:

```text
Repeats Monday
11:00 PM - 2:00 AM
```

At Tuesday 1:00 AM, the app still treats the Monday rule as active.

Added:

```swift
static func recurrenceSummary(for rule: Rule) -> String
```

What this does:

Returns display text like:

```text
Daily
Tue, Thu
One time: May 13, 2026
```

Added extension helper:

```swift
extension DeviceActivityName {
    var focusLockRuleID: UUID? { ... }
}
```

What this does:

- takes a DeviceActivity schedule name like `focus-lock-rule-UUID`
- extracts the original rule UUID
- lets the extension know which rule just started or ended

Result:

The schedule system now understands daily, custom weekday, one-time, and overnight rules.

---

### `focus-lock/DeviceActivityScheduleManager.swift`

This file registers schedules with iOS.

Updated:

```swift
let monitorableRules = rules.filter { FocusLockSchedule.isMonitorable($0) }
```

What this does:

- only valid, enabled, not-completed rules are registered with iOS

Updated schedule registration:

```swift
try center.startMonitoring(
    activityName,
    during: FocusLockSchedule.schedule(for: rule)
)
```

What this does:

- asks `FocusLockSchedule` to build the correct schedule
- recurring rules get `repeats: true`
- one-time rules get `repeats: false`

Added recurrence info to diagnostics.

Result:

The schedule manager does not need to know all recurrence details itself. It delegates that decision to `FocusLockSchedule`, keeping the logic centralized.

---

### `FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift`

This file runs in the background when iOS wakes the DeviceActivity extension.

Added:

```swift
private let center = DeviceActivityCenter()
```

What this does:

- lets the extension stop monitoring a completed one-time schedule

Updated:

```swift
override func intervalDidEnd(for activity: DeviceActivityName)
```

Added:

```swift
deleteCompletedOneTimeRuleIfNeeded(for: activity)
```

What this does:

- runs when iOS says a schedule interval ended
- checks if the ended schedule belongs to a one-time rule
- deletes the rule if it is completed
- saves the updated rules back to App Group storage
- stops monitoring that completed one-time activity

Added method:

```swift
private func deleteCompletedOneTimeRuleIfNeeded(for activity: DeviceActivityName)
```

Step-by-step:

1. Pulls the rule id out of the `DeviceActivityName`.
2. Loads saved rules from App Group storage.
3. Finds the rule that just ended.
4. If it is recurring, leaves it alone.
5. If it is one-time and completed, removes it.
6. Saves the remaining rules back to shared storage.
7. Stops monitoring the completed schedule.

Result:

One-time rules can delete themselves after completion even when the main app is closed.

Overlapping rules still work because after deletion, the extension calls:

```swift
refreshShields()
```

That recalculates shields from all remaining active rules instead of blindly clearing everything.

---

### `focus-lock/State/AppState.swift`

This file owns the app’s in-memory rule list.

Updated:

```swift
func addRule(...)
```

Added parameters:

```swift
repeatWeekdays: Set<Int> = Rule.allWeekdays
oneTimeDate: Date? = nil
```

What this does:

- lets create screens save recurrence information
- defaults to daily if no recurrence information is passed

Added:

```swift
let savedOneTimeDate = repeatWeekdays.isEmpty ? oneTimeDate : nil
```

What this does:

- keeps `oneTimeDate` only for one-time rules
- clears it for recurring rules because recurring rules do not need one exact date

Updated:

```swift
func editRule(...)
```

Added the same recurrence parameters so edit screens can update repeat behavior.

Added:

```swift
func refreshRulesFromStorage()
```

What this does:

- reloads `rules.json` from App Group storage
- useful when the extension deletes a one-time rule while the main app was closed/backgrounded

Updated:

```swift
private func loadRules() -> [Rule]
```

Now it removes completed one-time rules before returning saved rules.

Result:

The main app stays in sync with App Group storage and cleans up stale one-time rules if needed.

---

### `focus-lock/Views/CreateRuleView.swift`

This file is the new rule form.

Added state:

```swift
@State private var repeatWeekdays = Rule.allWeekdays
@State private var oneTimeDate = Date()
@State private var showRepeatSettings = false
```

What this does:

- tracks selected repeat days
- tracks the one-time rule date
- controls whether the repeat settings sheet is open

Added:

```swift
private var isOneTimeRule: Bool {
    repeatWeekdays.isEmpty
}
```

What this does:

- tells the form when no repeat days are selected
- when true, the rule is one-time

Changed the UI from inline weekday buttons to a clean row:

```text
Repeat     Daily
```

or:

```text
Repeat     Tue, Thu
```

or:

```text
Repeat     One time: May 13, 2026
```

Tapping this row opens a sheet.

Added:

```swift
RepeatSettingsView(repeatWeekdays: $repeatWeekdays)
```

What this does:

- opens the reusable repeat settings screen
- passes selected weekdays by binding so the sheet can edit the parent screen’s state

Added validation:

```swift
if FocusLockSchedule.isCompletedOneTimeRule(draftRule) {
    showCompletedOneTimeAlert = true
    return
}
```

What this does:

- prevents saving a one-time rule that already ended

Changed alert title to:

```text
Invalid Time Range
```

Result:

Users can create daily, custom, and one-time rules from a cleaner UI.

---

### `RepeatSettingsView`

This new reusable SwiftUI view currently lives in `CreateRuleView.swift`.

Purpose:

```text
Let the user choose repeat behavior in a sheet.
```

It supports:

```text
Does Not Repeat
Daily
Custom Days
```

Important property:

```swift
@Binding var repeatWeekdays: Set<Int>
```

What `@Binding` means:

- this sheet does not own the selected weekdays
- it edits the parent screen’s selected weekdays directly

Added:

```swift
repeatOptionRow(title:isSelected:)
```

What this does:

- builds one selectable row
- shows a checkmark when the option is selected

Added:

```swift
toggleRepeatWeekday(_:)
```

What this does:

- if a day is already selected, remove it
- if a day is not selected, add it

Result:

Create and edit screens share the same repeat selection UI.

---

### `focus-lock/Views/EditRuleView.swift`

This file is the edit rule form.

Added recurrence state:

```swift
@State private var repeatWeekdays: Set<Int>
@State private var oneTimeDate: Date
@State private var showRepeatSettings = false
```

Initialized from the existing rule:

```swift
_repeatWeekdays = State(initialValue: rule.repeatWeekdays)
_oneTimeDate = State(initialValue: rule.oneTimeDate ?? Date())
```

What this does:

- edit form opens with the saved repeat settings
- one-time rules show their saved date
- rules without a saved date fall back to today

Added the same tappable repeat row as create:

```text
Repeat     Daily
Repeat     Tue, Thu
Repeat     One time: May 13, 2026
```

Added:

```swift
RepeatSettingsView(repeatWeekdays: $repeatWeekdays)
```

What this does:

- reuses the same repeat settings sheet from create

Updated save logic:

```swift
repeatWeekdays: repeatWeekdays
oneTimeDate: isOneTimeRule ? oneTimeDate : nil
```

What this does:

- saves the updated repeat days
- only saves a one-time date when no repeat days are selected

Changed expired one-time alert title to:

```text
Invalid Time Range
```

Result:

Users can change an existing rule between daily, custom weekday, and one-time.

---

### `focus-lock/Views/RulesView.swift`

This file shows the list of saved rules.

Added:

```swift
Text(FocusLockSchedule.recurrenceSummary(for: rule))
```

What this does:

- displays how each rule repeats

Examples:

```text
Daily
Tue, Thu
One time: May 13, 2026
```

Result:

Users can see recurrence behavior directly from the rules list.

---

### `focus-lock/focus_lockApp.swift`

This is the app entry point.

Added:

```swift
@StateObject private var appState = AppState()
```

What this does:

- creates one shared `AppState` at the top of the app

Added:

```swift
@Environment(\.scenePhase) private var scenePhase
```

What this does:

- lets the app know when it becomes active, inactive, or backgrounded

Added:

```swift
.onChange(of: scenePhase) { newPhase in
    guard newPhase == .active else { return }
    appState.refreshRulesFromStorage()
}
```

What this does:

- when the app becomes active again, reload rules from App Group storage
- this catches rules deleted by the DeviceActivity extension while the main app was closed/backgrounded

Result:

Completed one-time rules disappear from the UI when the user reopens the app.

---

### `focus-lock/ContentView.swift`

This file is the app’s root UI.

Changed:

```swift
@StateObject private var appState = AppState()
```

to:

```swift
@EnvironmentObject private var appState: AppState
```

What this does:

- `ContentView` no longer creates its own separate app state
- it uses the shared app state created in `focus_lockApp`

Updated the preview:

```swift
ContentView()
    .environmentObject(AppState())
```

What this does:

- gives Xcode previews the `AppState` object they need

Result:

The app now has one shared source of truth for rules.

## User-Facing Results

Users can now:

- create daily repeating rules
- create custom weekday repeating rules
- create one-time rules
- edit a rule’s repeat behavior
- see recurrence behavior in the rules list
- avoid saving one-time rules that already ended
- rely on one-time rules deleting themselves after completion

## Background Behavior

When a one-time rule ends:

1. iOS calls `intervalDidEnd`.
2. The DeviceActivity extension finds the rule that ended.
3. If it is one-time, it deletes it from App Group storage.
4. The extension refreshes shields from remaining active rules.
5. If another overlapping rule is still active, shared apps stay blocked.
6. When the main app opens again, it reloads rules from storage and no longer shows the completed one-time rule.

## Verification

Focused Swift type-checks passed for the recurrence model, schedule logic, AppState, DeviceActivity monitor extension, create view, and edit view.

A full local Xcode build should still be run before merging because the local Codex sandbox blocked some SwiftUI preview/build tooling during full-project verification.

## Manual Testing Recommended

Test on a real iPhone, not the simulator.

Important cases:

- daily rule blocks and unblocks
- custom weekday rule only runs on selected days
- one-time rule blocks, ends, and deletes itself
- one-time rule cannot be saved if already expired
- overlapping one-time and recurring rules keep shared apps blocked correctly
- overnight one-time rule, such as 11 PM to 2 AM
- overnight recurring rule, such as Monday 11 PM to Tuesday 2 AM
```