### PR TITLE
Updated Rules View

### DIFF
--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -16,6 +16,134 @@ struct RulesView: View {
     @State private var ruleBeingEdited: Rule?
     
     @State private var goToBlocked = false
+
+    // Describes the user-facing state shown on each rule row.
+    //
+    // This is intentionally local to RulesView for now because the current task only changes
+    // how the Rules screen looks. If Home and Rules later need the exact same status model,
+    // this enum would be a good candidate to move into Shared/.
+    private enum RuleDisplayStatus {
+        case active
+        case scheduled
+        case disabled
+        case invalid(String)
+        case completed
+
+        // The short text shown inside the colored status pill on each rule card.
+        var title: String {
+            switch self {
+            case .active:
+                return "Active now"
+            case .scheduled:
+                return "Scheduled"
+            case .disabled:
+                return "Disabled"
+            case .invalid:
+                return "Needs attention"
+            case .completed:
+                return "Completed"
+            }
+        }
+
+        // The supporting sentence shown under the status pill.
+        //
+        // Invalid rules carry their own reason so the user knows what to fix.
+        var detail: String {
+            switch self {
+            case .active:
+                return "Blocking distractions right now"
+            case .scheduled:
+                return "Will turn on at the next scheduled time"
+            case .disabled:
+                return "Turn this rule on when you want it to run"
+            case .invalid(let reason):
+                return reason
+            case .completed:
+                return "This one-time rule has ended"
+            }
+        }
+
+        // Chooses an SF Symbol that visually matches the status.
+        var iconName: String {
+            switch self {
+            case .active:
+                return "lock.shield.fill"
+            case .scheduled:
+                return "clock.fill"
+            case .disabled:
+                return "pause.circle.fill"
+            case .invalid:
+                return "exclamationmark.triangle.fill"
+            case .completed:
+                return "checkmark.seal.fill"
+            }
+        }
+
+        // Main status color used by the badge and helper text.
+        var tint: Color {
+            switch self {
+            case .active:
+                return .green
+            case .scheduled:
+                return .orange
+            case .disabled:
+                return .secondary
+            case .invalid:
+                return .red
+            case .completed:
+                return .secondary
+            }
+        }
+
+        // Border color for the whole rule card.
+        //
+        // Active and scheduled rules get stronger borders because those are the states
+        // the user is most likely checking at a glance.
+        var borderColor: Color {
+            switch self {
+            case .active:
+                return .green
+            case .scheduled:
+                return .orange
+            case .invalid:
+                return .red
+            default:
+                return Color(.separator)
+            }
+        }
+
+        // Optional glow around the whole rule card.
+        //
+        // Green means the rule is protecting the user now.
+        // Orange means the rule is scheduled for a future window.
+        var glowColor: Color? {
+            switch self {
+            case .active:
+                return .green
+            case .scheduled:
+                return .orange
+            default:
+                return nil
+            }
+        }
+
+        // Controls where the row appears in the Rules list.
+        //
+        // Active rules are most urgent, so they go first.
+        // Scheduled rules are useful but less urgent, so they go last.
+        // The middle group keeps disabled, invalid, and completed rules visible without
+        // pushing active protection out of the user's first view.
+        var sortPriority: Int {
+            switch self {
+            case .active:
+                return 0
+            case .invalid, .disabled, .completed:
+                return 1
+            case .scheduled:
+                return 2
+            }
+        }
+    }
     
     // Builds the saved selection text for one rule in the rules list.
     private func selectedActivitySummary(for rule: Rule) -> String {
@@ -80,64 +208,108 @@ struct RulesView: View {
             }
             
             
-            ScrollView(.vertical, showsIndicators: false) {
-                LazyVStack(alignment:.leading, spacing: 16) {
-    
-                    ForEach($appState.rules){ $rule in
-                        VStack(alignment: .leading, spacing: 4){
-                            HStack{
-                                Text(rule.title)
-                                    .font(.title2)
-                                    .bold()
-                                Spacer()
-                                
-                                Image(systemName: rule.isEnabled ? "checkmark.circle.fill" : "xmark.circle.fill")
-                                    .foregroundStyle(rule.isEnabled ? .green : .red)
-                                    .font(.title2)
-                                    .onTapGesture {
-                                        // Toggle through AppState so the actual Screen Time shield updates too.
-                                        appState.toggleRule(id: rule.id)
+            // Rebuilds this part of the screen every second.
+            //
+            // Rule status can change just because time passes, so this lets a scheduled
+            // rule turn green soon after its start time without reopening the screen.
+            TimelineView(.periodic(from: Date(), by: 1)) { timeline in
+                ScrollView(.vertical, showsIndicators: false) {
+                    LazyVStack(alignment:.leading, spacing: 16) {
+        
+                        // Shows rules in status order instead of raw saved order.
+                        //
+                        // Active rules move to the top. Scheduled rules move to the bottom.
+                        // When a recurring active rule ends, the next timeline tick recalculates
+                        // its status as scheduled and moves it down.
+                        ForEach(sortedRules(now: timeline.date)){ rule in
+                            // Calculate the status once per row so the badge, text, border,
+                            // glow, and sorting all describe the same state.
+                            let status = ruleDisplayStatus(for: rule, now: timeline.date)
+
+                            VStack(alignment: .leading, spacing: 12){
+                                HStack(alignment: .top, spacing: 12){
+                                    VStack(alignment: .leading, spacing: 8) {
+                                        Text(rule.title)
+                                            .font(.title2)
+                                            .bold()
+
+                                        // Shows the compact "Active now" / "Scheduled" / etc. pill.
+                                        statusBadge(status)
                                     }
-                                
-                                //Editing Rule Button
-                                Button(action: {
-                                    //Updated state var with rule that is currently being edited and goes back to .sheet to call EditRuleView
-                                    ruleBeingEdited = rule
-                                }) {
-                                    Image(systemName: "pencil")
-                                        .foregroundStyle(.blue)
-                                        .font(.title2)
-                                }
-                                .buttonStyle(BorderlessButtonStyle())
-                                
-                                
-                                Button(action:{
+
+                                    Spacer()
                                     
-                                    appState.deleteRule(id:rule.id)
-                                }){
-                                    Image(systemName: "trash")
-                                        .foregroundStyle(.red)
+                                    Image(systemName: rule.isEnabled ? "checkmark.circle.fill" : "xmark.circle.fill")
+                                        .foregroundStyle(rule.isEnabled ? .green : .red)
                                         .font(.title2)
+                                        .onTapGesture {
+                                            // Toggle through AppState so the actual Screen Time shield updates too.
+                                            appState.toggleRule(id: rule.id)
+                                        }
+                                    
+                                    //Editing Rule Button
+                                    Button(action: {
+                                        //Updated state var with rule that is currently being edited and goes back to .sheet to call EditRuleView
+                                        ruleBeingEdited = rule
+                                    }) {
+                                        Image(systemName: "pencil")
+                                            .foregroundStyle(.blue)
+                                            .font(.title2)
+                                    }
+                                    .buttonStyle(BorderlessButtonStyle())
+                                    
+                                    
+                                    Button(action:{
+                                        
+                                        appState.deleteRule(id:rule.id)
+                                    }){
+                                        Image(systemName: "trash")
+                                            .foregroundStyle(.red)
+                                            .font(.title2)
+                                    }
+                                    .buttonStyle(BorderlessButtonStyle())
                                 }
-                                .buttonStyle(BorderlessButtonStyle())
+
+                                Text(status.detail)
+                                    .font(.caption)
+                                    .foregroundStyle(status.tint)
+                                
+                                Text("\(rule.startTime, style: .time) - \(rule.endTime, style: .time)")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.gray)
+                                
+                                // Shows whether this rule is daily, one-time, or repeats on selected weekdays.
+                                Text(FocusLockSchedule.recurrenceSummary(for: rule))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                
+                                
+                                // Shows how many picker items this rule contains.
+                                Text(selectedActivitySummary(for: rule))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
                             }
-                            Text("\(rule.startTime, style: .time) - \(rule.endTime, style: .time)")
-                                .font(.subheadline)
-                                .foregroundStyle(.gray)
-                            
-                            // Shows whether this rule is daily, one-time, or repeats on selected weekdays.
-                            Text(FocusLockSchedule.recurrenceSummary(for: rule))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                            
-                            
-                            // Shows how many picker items this rule contains.
-                            Text(selectedActivitySummary(for: rule))
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
+                            .padding(14)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .background(Color(.secondarySystemGroupedBackground))
+                            .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                            // Draws the status-colored outline around the rule card.
+                            .overlay(
+                                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                                    .stroke(status.borderColor.opacity(0.85), lineWidth: 1.5)
+                            )
+                            // Adds the green/orange glow for active and scheduled rules.
+                            .shadow(color: status.glowColor?.opacity(0.32) ?? .clear, radius: 12, x: 0, y: 0)
+                            .shadow(color: status.glowColor?.opacity(0.18) ?? .clear, radius: 22, x: 0, y: 0)
                         }
-                        Divider()
                     }
+                    // Animates row movement when a status change changes the sorted order.
+                    .animation(.easeInOut(duration: 0.25), value: sortedRuleIDs(now: timeline.date))
+                }
+                // While the user is already on this screen, remove completed one-time rules
+                // instead of waiting for an app relaunch or the DeviceActivity extension callback.
+                .onChange(of: timeline.date) { now in
+                    removeCompletedOneTimeRulesIfNeeded(now: now)
                 }
             }
             
@@ -148,6 +320,159 @@ struct RulesView: View {
         .navigationDestination(isPresented: $goToBlocked) {
             BlockedView()
         }
+    }
+
+    // Builds the compact colored status pill shown under the rule title.
+    private func statusBadge(_ status: RuleDisplayStatus) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: status.iconName)
+                .font(.caption.weight(.semibold))
+
+            Text(status.title)
+                .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(status.tint)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(status.tint.opacity(0.12))
+        .clipShape(Capsule())
+    }
+
+    // Converts one saved Rule into the status the user should see right now.
+    //
+    // Order matters:
+    // - disabled wins first because disabled rules should never appear active
+    // - invalid comes before active/scheduled because an invalid rule cannot run
+    // - active comes before scheduled because the rule is protecting right now
+    // - scheduled means it has a future start date
+    // - completed is the fallback, mostly for ended one-time rules before cleanup runs
+    private func ruleDisplayStatus(for rule: Rule, now: Date) -> RuleDisplayStatus {
+        if !rule.isEnabled {
+            return .disabled
+        }
+
+        if let invalidReason = invalidReason(for: rule) {
+            return .invalid(invalidReason)
+        }
+
+        if FocusLockSchedule.isActive(rule, now: now) {
+            return .active
+        }
+
+        if nextStartDate(for: rule, after: now) != nil {
+            return .scheduled
+        }
+
+        return .completed
+    }
+
+    // Returns a user-readable reason when a rule cannot actually run.
+    private func invalidReason(for rule: Rule) -> String? {
+        if !FocusLockSchedule.hasSelectedActivity(rule.activitySelection) {
+            return "Choose at least one app, category, or website"
+        }
+
+        if FocusLockSchedule.durationMinutes(for: rule) < FocusLockSchedule.minimumMonitorDurationMinutes {
+            return "Rule must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes long"
+        }
+
+        if rule.isOneTime && rule.oneTimeDate == nil {
+            return "Choose a date for this one-time rule"
+        }
+
+        return nil
+    }
+
+    // Finds the next future start time for a rule.
+    //
+    // One-time rules only have one possible start.
+    // Recurring rules scan the next week because any weekly recurrence should appear
+    // again within seven days if it has selected weekdays.
+    private func nextStartDate(for rule: Rule, after now: Date) -> Date? {
+        if rule.isOneTime {
+            guard let oneTimeDate = rule.oneTimeDate else {
+                return nil
+            }
+
+            let start = date(on: oneTimeDate, matchingTimeFrom: rule.startTime)
+            return start > now ? start : nil
+        }
+
+        for dayOffset in 0...7 {
+            guard let candidateDay = Calendar.current.date(byAdding: .day, value: dayOffset, to: now) else {
+                continue
+            }
+
+            let weekday = Calendar.current.component(.weekday, from: candidateDay)
+            guard rule.repeatWeekdays.contains(weekday) else {
+                continue
+            }
+
+            let start = date(on: candidateDay, matchingTimeFrom: rule.startTime)
+            if start > now {
+                return start
+            }
+        }
+
+        return nil
+    }
+
+    // Sorts the rule cards by their current status while preserving saved order inside
+    // each status group.
+    private func sortedRules(now: Date) -> [Rule] {
+        appState.rules
+            .enumerated()
+            .sorted { left, right in
+                let leftPriority = ruleDisplayStatus(for: left.element, now: now).sortPriority
+                let rightPriority = ruleDisplayStatus(for: right.element, now: now).sortPriority
+
+                if leftPriority != rightPriority {
+                    return leftPriority < rightPriority
+                }
+
+                return left.offset < right.offset
+            }
+            .map(\.element)
+    }
+
+    // Gives SwiftUI a stable animation value that changes only when the visible order changes.
+    private func sortedRuleIDs(now: Date) -> [UUID] {
+        sortedRules(now: now).map(\.id)
+    }
+
+    // Deletes completed one-time rules while the Rules screen is open.
+    //
+    // AppState also cleans these up on launch, and the DeviceActivity extension cleans them
+    // up after interval end. This helper keeps the on-screen list from showing a finished
+    // one-time rule until the user leaves and reopens the app.
+    private func removeCompletedOneTimeRulesIfNeeded(now: Date) {
+        let completedRuleIDs = appState.rules
+            .filter { FocusLockSchedule.isCompletedOneTimeRule($0, now: now) }
+            .map(\.id)
+
+        guard !completedRuleIDs.isEmpty else {
+            return
+        }
+
+        for ruleID in completedRuleIDs {
+            appState.deleteRule(id: ruleID)
+        }
+    }
+
+    // Combines a calendar day with the hour/minute from a stored rule time.
+    //
+    // Rules store startTime/endTime as Date values, but recurring rules only care about
+    // the clock time. This helper lets the view ask, "what would this rule's start time
+    // be on this candidate day?"
+    private func date(on day: Date, matchingTimeFrom time: Date) -> Date {
+        let timeComponents = Calendar.current.dateComponents([.hour, .minute], from: time)
+
+        return Calendar.current.date(
+            bySettingHour: timeComponents.hour ?? 0,
+            minute: timeComponents.minute ?? 0,
+            second: 0,
+            of: day
+        ) ?? day
     }
     
 }


### PR DESCRIPTION
This PR updates `RulesView.swift` so the Rules screen communicates rule state more clearly and reacts as time passes.

The main change is that each rule row now has a user-visible status. Instead of only showing a green checkmark or red x for enabled/disabled, the row now calculates whether the rule is active, scheduled, disabled, invalid, or completed. This gives users a better answer to the important question: “Is this rule actually protecting me right now?”

**What Changed**

I added a local `RuleDisplayStatus` enum inside `RulesView.swift`.

It supports:

- `Active now`
- `Scheduled`
- `Disabled`
- `Needs attention`
- `Completed`

Each status controls its own label, helper text, icon, color, border color, glow color, and sorting priority. Keeping that grouped together makes the row UI easier to understand and avoids scattering status-specific styling throughout the view.

Active rules now show with a green visual treatment:

- green status badge
- green border
- green glow around the rule card
- `lock.shield.fill` icon
- helper text saying it is blocking distractions right now

Scheduled rules now show with an orange visual treatment:

- orange status badge
- orange border
- orange glow around the rule card
- `clock.fill` icon
- helper text saying it will turn on at the next scheduled time

This means a rule that is waiting for a future window looks visually different from a rule that is protecting the user right now.

**Rule Ordering**

The Rules screen now sorts rows by status instead of always using saved order.

Active rules move to the top of the list, because those are the most important rules for the user to see immediately.

Scheduled rules move to the bottom of the list. This matches the behavior we wanted: once an active recurring rule finishes and becomes scheduled for its next run, it drops back down with the other scheduled rules.

Rules that are disabled, invalid, or completed stay in the middle. Within each group, the original saved order is preserved, so the list does not feel randomly shuffled.

The sort order is:

1. Active
2. Invalid / Disabled / Completed
3. Scheduled

I also added a small animation so rows move smoothly when their status changes.

**Automatic Refresh**

The Rules screen now uses `TimelineView` with a 1-second interval.

Previously, the status only refreshed every 60 seconds. That meant a rule could start or end, but the UI might not change color immediately. With the 1-second refresh, the screen recalculates rule status much faster.

This affects:

- active rules turning green near their start time
- active rules becoming scheduled again after they end
- recurring rules moving from the top back to the bottom
- one-time rules being removed shortly after completion

The active check uses the existing `FocusLockSchedule.isActive(...)` helper, so overnight rules continue to rely on the shared schedule logic instead of duplicating that math in the view.

**One-Time Rule Cleanup**

One-time rules are supposed to be removed after they finish. The project already had cleanup paths in `AppState` on relaunch and in the DeviceActivity monitor extension when iOS calls the interval end callback.

However, if the user was already sitting on the Rules screen, the in-memory list could still show the completed one-time rule until storage was refreshed or the app became active again.

To make the Rules screen feel correct in real time, I added a `removeCompletedOneTimeRulesIfNeeded(now:)` helper inside `RulesView.swift`.

On each timeline tick, it checks for completed one-time rules using:

```swift
FocusLockSchedule.isCompletedOneTimeRule(rule, now: now)
```

If it finds any, it deletes them through:

```swift
appState.deleteRule(id: ruleID)
```

That keeps the UI, saved rules, schedules, and shields going through the normal `AppState` update flow.

**Invalid Rule Messaging**

The Rules screen now shows a “Needs attention” state for rules that cannot run.

Right now it explains these cases:

- no apps, categories, or websites selected
- rule duration is shorter than `FocusLockSchedule.minimumMonitorDurationMinutes`
- one-time rule is missing its date

This gives the user a reason instead of silently showing a rule that will not actually protect them.

**Files Changed**

Only this file was changed:

[RulesView.swift](/Users/surajmodur/Downloads/focus-lock/focus-lock/focus-lock/Views/RulesView.swift)

No shared model files, schedule helpers, AppState logic, or extension code were changed. This keeps the PR scoped to the Rules screen UI behavior.

**Testing Notes**

Manual cases to test on device:

1. Create a recurring rule that is currently active.
   - It should appear at the top.
   - It should glow green.
   - It should say `Active now`.

2. Create a recurring rule scheduled for later today or tomorrow.
   - It should appear near the bottom.
   - It should glow orange.
   - It should say `Scheduled`.

3. Let an active recurring rule pass its end time.
   - It should stop glowing green.
   - It should become scheduled again.
   - It should move down with the scheduled rules.

4. Create an overnight rule.
   - It should still turn green during the overnight active window.
   - After the overnight window ends, it should return to scheduled.

5. Create or edit a rule with no selected apps/categories/websites.
   - It should show `Needs attention`.
   - It should explain that the user needs to choose at least one target.

6. Create or load a too-short rule.
   - It should show `Needs attention`.
   - It should explain that the rule must be at least the minimum allowed duration.

7. Create a one-time rule and let it finish.
   - It should disappear from the Rules screen shortly after its end time.