### PR TITLE
Stabilize Habits MVP report layout

### DIFF
--- a/focus-lock/FocusLockDeviceActivityReport/FocusLockHabitsReport.swift
+++ b/focus-lock/FocusLockDeviceActivityReport/FocusLockHabitsReport.swift
@@ -117,20 +117,18 @@ struct FocusLockHabitsReportView: View {
     let configuration: FocusLockHabitsConfiguration
 
     var body: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 18) {
-                if let lastUpdatedDate = configuration.lastUpdatedDate {
-                    Text("Updated \(lastUpdatedDate.formatted(date: .omitted, time: .shortened))")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
-                summaryGrid
-
-                appsSection
+        VStack(alignment: .leading, spacing: 18) {
+            if let lastUpdatedDate = configuration.lastUpdatedDate {
+                Text("Updated \(lastUpdatedDate.formatted(date: .omitted, time: .shortened))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-            .padding(.bottom, 120)
+
+            summaryGrid
+
+            appsSection
         }
+        .padding(.top, 72)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }
 
@@ -169,7 +167,7 @@ struct FocusLockHabitsReportView: View {
     private var appsSection: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack {
-                Text("Apps")
+                Text("Top apps")
                     .font(.headline)
             }
 
@@ -193,7 +191,7 @@ struct FocusLockHabitsReportView: View {
     }
 
     private var visibleApps: [FocusLockAppActivityRow] {
-        configuration.apps
+        Array(configuration.apps.prefix(5))
     }
 
     private var columns: [GridItem] {
@@ -204,13 +202,13 @@ struct FocusLockHabitsReportView: View {
     }
 
     private func metricTile(title: String, value: String, systemImage: String, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 6) {
             Image(systemName: systemImage)
-                .font(.headline)
+                .font(.subheadline)
                 .foregroundStyle(tint)
 
             Text(value)
-                .font(.title3.bold())
+                .font(.headline.bold())
                 .monospacedDigit()
                 .lineLimit(1)
                 .minimumScaleFactor(0.75)
@@ -221,8 +219,8 @@ struct FocusLockHabitsReportView: View {
                 .lineLimit(2)
                 .minimumScaleFactor(0.85)
         }
-        .padding(14)
-        .frame(maxWidth: .infinity, minHeight: 118, alignment: .leading)
+        .padding(10)
+        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
         .background(Color(.tertiarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }

--- a/focus-lock/focus-lock/Views/HabitsView.swift
+++ b/focus-lock/focus-lock/Views/HabitsView.swift
@@ -18,6 +18,7 @@ struct HabitsView: View {
             rangePicker
 
             DeviceActivityReport(.focusLockHabits, filter: selectedRange.filter)
+                .id(selectedRange.rawValue)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
         .padding(20)


### PR DESCRIPTION
## Summary
- keep the Habits report as a compact MVP surface after PR #51 merged
- avoid flaky embedded Screen Time report scrolling by showing summary metrics and top apps only
- force the report host to recreate when switching Today / Week / Month
- add a small top buffer and compact metric tiles to avoid clipping in Apple's hosted report view

## Follow-up
Created #53 to revisit a richer Habits report layout and longer app lists after MVP 1.

## Testing
- Built generic iOS target with CODE_SIGNING_ALLOWED=NO
- Installed on Shabarish’s iPhone for real-device testing
- User confirmed this MVP works ~99% of the time, with occasional loading delay for range changes