### PR TITLE
Stabilize Habits report dashboard

### DIFF
--- a/focus-lock/FocusLockDeviceActivityReport/FocusLockHabitsReport.swift
+++ b/focus-lock/FocusLockDeviceActivityReport/FocusLockHabitsReport.swift
@@ -117,7 +117,7 @@ struct FocusLockHabitsReportView: View {
     let configuration: FocusLockHabitsConfiguration
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 18) {
+        VStack(alignment: .leading, spacing: 12) {
             if let lastUpdatedDate = configuration.lastUpdatedDate {
                 Text("Updated \(lastUpdatedDate.formatted(date: .omitted, time: .shortened))")
                     .font(.caption)
@@ -128,12 +128,13 @@ struct FocusLockHabitsReportView: View {
 
             appsSection
         }
-        .padding(.top, 72)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        // Cover the main app's loading indicator once this extension view is ready.
+        .background(Color(.systemGroupedBackground))
     }
 
     private var summaryGrid: some View {
-        LazyVGrid(columns: columns, spacing: 12) {
+        LazyVGrid(columns: columns, spacing: 8) {
             metricTile(
                 title: "Screen time",
                 value: formattedDuration(configuration.totalActivityDuration),
@@ -165,7 +166,7 @@ struct FocusLockHabitsReportView: View {
     }
 
     private var appsSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
+        VStack(alignment: .leading, spacing: 6) {
             HStack {
                 Text("Top apps")
                     .font(.headline)
@@ -196,13 +197,13 @@ struct FocusLockHabitsReportView: View {
 
     private var columns: [GridItem] {
         [
-            GridItem(.flexible(), spacing: 12),
-            GridItem(.flexible(), spacing: 12)
+            GridItem(.flexible(), spacing: 8),
+            GridItem(.flexible(), spacing: 8)
         ]
     }
 
     private func metricTile(title: String, value: String, systemImage: String, tint: Color) -> some View {
-        VStack(alignment: .leading, spacing: 6) {
+        VStack(alignment: .leading, spacing: 4) {
             Image(systemName: systemImage)
                 .font(.subheadline)
                 .foregroundStyle(tint)
@@ -219,14 +220,14 @@ struct FocusLockHabitsReportView: View {
                 .lineLimit(2)
                 .minimumScaleFactor(0.85)
         }
-        .padding(10)
-        .frame(maxWidth: .infinity, minHeight: 88, alignment: .leading)
+        .padding(8)
+        .frame(maxWidth: .infinity, minHeight: 72, alignment: .leading)
         .background(Color(.tertiarySystemGroupedBackground))
         .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
     }
 
     private func appRow(_ app: FocusLockAppActivityRow) -> some View {
-        HStack(spacing: 12) {
+        HStack(spacing: 10) {
             appIcon(app)
 
             VStack(alignment: .leading, spacing: 6) {
@@ -243,14 +244,14 @@ struct FocusLockHabitsReportView: View {
                 .foregroundStyle(.secondary)
             }
 
-            Spacer(minLength: 12)
+            Spacer(minLength: 8)
 
             Text(formattedDuration(app.duration))
                 .font(.subheadline.weight(.semibold))
                 .foregroundStyle(.secondary)
                 .monospacedDigit()
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 5)
     }
 
     @ViewBuilder
@@ -258,12 +259,12 @@ struct FocusLockHabitsReportView: View {
         if let token = app.token {
             Label(token)
                 .labelStyle(.iconOnly)
-                .frame(width: 34, height: 34)
+                .frame(width: 30, height: 30)
         } else {
             Image(systemName: "app.dashed")
                 .font(.headline)
                 .foregroundStyle(.secondary)
-                .frame(width: 34, height: 34)
+                .frame(width: 30, height: 30)
                 .background(Color(.tertiarySystemGroupedBackground))
                 .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
         }

--- a/focus-lock/focus-lock/Views/HabitsView.swift
+++ b/focus-lock/focus-lock/Views/HabitsView.swift
@@ -12,33 +12,42 @@ struct HabitsView: View {
     @State private var selectedRange: HabitRange = .today
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 20) {
-            header
-
+        // Keep Habits as one fixed dashboard. DeviceActivityReport is hosted by
+        // a separate extension process, and scroll gestures across that boundary
+        // were unreliable on a real iPhone.
+        VStack(alignment: .leading, spacing: 12) {
             rangePicker
 
-            DeviceActivityReport(.focusLockHabits, filter: selectedRange.filter)
-                .id(selectedRange.rawValue)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            ZStack {
+                // DeviceActivityReport does not expose a loading callback to the
+                // main app. This remains visible behind the report until Apple's
+                // extension host finishes rendering its opaque content.
+                VStack(spacing: 10) {
+                    ProgressView()
+
+                    Text("Loading activity...")
+                        .font(.subheadline.weight(.medium))
+
+                    Text("Weekly and monthly reports may take a moment.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .multilineTextAlignment(.center)
+                }
+
+                DeviceActivityReport(.focusLockHabits, filter: selectedRange.filter)
+                    // Recreate Apple's report host when the range changes so old
+                    // Today/Week/Month results do not remain on screen.
+                    .id(selectedRange.rawValue)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
-        .padding(20)
+        .padding(.horizontal, 20)
+        .padding(.top, 8)
         .background(Color(.systemGroupedBackground))
-        .safeAreaPadding(.bottom, 96)
+        .safeAreaPadding(.bottom, 88)
         .navigationTitle("Habits")
         .navigationBarTitleDisplayMode(.inline)
-    }
-
-    private var header: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Screen habits")
-                .font(.largeTitle.bold())
-
-            Text("See where your attention is going, then tune your rules around the real patterns.")
-                .font(.subheadline)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     private var rangePicker: some View {


### PR DESCRIPTION
## Summary

Reworks the Habits tab into a compact, fixed dashboard that avoids unreliable scrolling across Apple's `DeviceActivityReport` extension boundary.

## Why

On a real iPhone, scrolling inside or around `DeviceActivityReport` was inconsistent. Drag gestures could work once, become difficult to trigger, or leave the report stuck partway down.

For MVP 1, this PR uses a stable no-scroll design instead of adding more gesture workarounds around Apple's separately hosted report view.

## Changes

- Removes the large Screen habits heading and supporting copy.
- Keeps Today, Week, and Month as a compact segmented picker.
- Uses a fixed dashboard with no parent or extension `ScrollView`.
- Compacts the four summary metrics.
- Shows the five highest-usage apps with duration, pickups, and notifications.
- Removes the old 72-point report offset workaround.
- Adds an indeterminate loading state while Apple prepares the report.
- Notes that weekly and monthly reports may take a moment.
- Uses an opaque report background so loaded content replaces the loading state.

## Privacy Notes

`DeviceActivityReport` does not expose loading percentage or a completion callback to the main app. The indicator is intentionally indeterminate, and raw Screen Time data remains inside the report extension.

## Verification

Generic iOS Debug build passes:

```bash
xcodebuild -project focus-lock/focus-lock.xcodeproj -scheme focus-lock -configuration Debug -destination generic/platform=iOS -derivedDataPath /private/tmp/focus-lock-habits-loading-copy-derived CODE_SIGNING_ALLOWED=NO build
```

## Real-Device Test Plan

- Open Habits and confirm the dashboard fits above the floating tab bar.
- Confirm all four metrics and up to five top apps are visible.
- Switch between Today, Week, and Month.
- Confirm the loading indicator appears while longer reports are prepared.
- Confirm loaded content replaces the loading state.
- Confirm there is no clipped content or unreliable scrolling interaction.
- Check light and dark mode.

Closes #53.
