### PR TITLE
Time restrict feature

### DIFF
--- a/focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
+++ b/focus-lock/FocusLockDeviceActivityMonitor/DeviceActivityMonitorExtension.swift
@@ -7,6 +7,9 @@
 // iOS calls this extension when a registered schedule starts or ends.
 import DeviceActivity
 
+// Foundation gives us Date for recording when a usage limit was reached.
+import Foundation
+
 // ManagedSettings gives us ManagedSettingsStore.
 // That store is how we apply or remove shields.
 import ManagedSettings
@@ -37,6 +40,9 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
         // Let Apple's base class do any default work first.
         super.intervalDidStart(for: activity)
 
+        // Usage-limit rules reset when their daily monitoring interval starts.
+        clearExpiredUsageLimitStateIfNeeded()
+
         // Recompute which apps should be blocked right now.
         refreshShields()
     }
@@ -62,6 +68,20 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
         refreshShields()
     }
 
+    // iOS calls this when a monitored usage-limit event reaches its threshold.
+    //
+    // Example:
+    // Rule allows 30 minutes of Instagram today.
+    // Once iOS counts 30 minutes of selected activity, this method fires.
+    override func eventDidReachThreshold(_ event: DeviceActivityEvent.Name, activity: DeviceActivityName) {
+        FocusLockDiagnostics.record("DeviceActivityMonitor eventDidReachThreshold fired for event=\(event.rawValue), activity=\(activity.rawValue).")
+
+        super.eventDidReachThreshold(event, activity: activity)
+
+        markUsageLimitReachedIfNeeded(for: event)
+        refreshShields()
+    }
+
     // Shared helper used by both intervalDidStart and intervalDidEnd.
     private func refreshShields() {
         let appGroupAvailable = FocusLockDiagnostics.appGroupContainerURL() != nil
@@ -71,7 +91,7 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
         //
         // This works while the app is closed because the extension can read the same
         // shared App Group storage.
-        let rules = FocusLockRuleStore.loadRules()
+        let rules = cleanedRulesFromStorage()
         FocusLockDiagnostics.record("DeviceActivityMonitor loaded \(rules.count) rule(s).")
 
         // Ask the shared schedule helper which app tokens should be blocked at this moment.
@@ -103,6 +123,52 @@ final class DeviceActivityMonitorExtension: DeviceActivityMonitor {
 
         // Record whether the monitor cleared every shield or applied at least one shield.
         FocusLockDiagnostics.record(hasActiveShields ? "DeviceActivityMonitor applied shields." : "DeviceActivityMonitor cleared shields.")
+    }
+
+    // Loads rules and clears stale usage-limit reached state before using them.
+    private func cleanedRulesFromStorage() -> [Rule] {
+        let rules = FocusLockRuleStore.loadRules()
+        let cleanedRules = FocusLockSchedule.clearingExpiredUsageLimitState(from: rules)
+
+        let didClearAnyUsageLimitState = zip(rules, cleanedRules).contains { oldRule, newRule in
+            oldRule.usageLimitReachedAt != newRule.usageLimitReachedAt
+        }
+
+        if didClearAnyUsageLimitState {
+            FocusLockRuleStore.saveRules(cleanedRules)
+            FocusLockDiagnostics.record("DeviceActivityMonitor cleared expired usage-limit state while loading rules.")
+        }
+
+        return cleanedRules
+    }
+
+    // Clears yesterday's reached flags so usage-limit rules reset for the new day.
+    private func clearExpiredUsageLimitStateIfNeeded() {
+        _ = cleanedRulesFromStorage()
+    }
+
+    // Marks a usage-limit rule as reached after iOS fires its threshold event.
+    private func markUsageLimitReachedIfNeeded(for event: DeviceActivityEvent.Name) {
+        guard let reachedRuleID = event.focusLockUsageLimitRuleID else {
+            FocusLockDiagnostics.record("DeviceActivityMonitor ignored non-Focus-Lock threshold event \(event.rawValue).")
+            return
+        }
+
+        var rules = FocusLockRuleStore.loadRules()
+
+        guard let index = rules.firstIndex(where: { $0.id == reachedRuleID }) else {
+            FocusLockDiagnostics.record("DeviceActivityMonitor found no saved rule for threshold event \(event.rawValue).")
+            return
+        }
+
+        guard rules[index].ruleKind == .usageLimit else {
+            FocusLockDiagnostics.record("DeviceActivityMonitor ignored threshold event for non-usage-limit rule \(rules[index].id).")
+            return
+        }
+
+        rules[index].usageLimitReachedAt = Date()
+        FocusLockRuleStore.saveRules(rules)
+        FocusLockDiagnostics.record("DeviceActivityMonitor marked usage-limit rule \(rules[index].id) as reached.")
     }
     
     // Deletes a one-time rule after iOS tells us its interval ended.

--- a/focus-lock/Shared/FocusLockSchedule.swift
+++ b/focus-lock/Shared/FocusLockSchedule.swift
@@ -67,6 +67,11 @@ enum FocusLockSchedule {
         // Checks that the rule is long enough for DeviceActivity.
         let hasEnoughDuration = durationMinutes(for: rule) >= minimumMonitorDurationMinutes
 
+        // Usage-limit rules do not use recurrence settings, but they still need a valid limit.
+        if rule.ruleKind == .usageLimit {
+            return isEnabled && hasActivity && hasEnoughDuration
+        }
+
         // Checks that recurrence data is valid.
         let recurrenceIsValid = hasValidRecurrence(rule)
 
@@ -91,6 +96,11 @@ enum FocusLockSchedule {
 
     // Checks whether the current time is inside this rule's blocking window.
     static func isActive(_ rule: Rule, now: Date = Date()) -> Bool {
+        // Usage-limit rules become active only after iOS tells us today's limit was reached.
+        if rule.ruleKind == .usageLimit {
+            return hasReachedUsageLimitToday(rule, now: now)
+        }
+
         // Uses exact dates for one-time rules.
         if rule.isOneTime {
             // Returns whether this exact one-time session is active now.
@@ -166,6 +176,11 @@ enum FocusLockSchedule {
 
     // Builds the DeviceActivity schedule that iOS will monitor.
     static func schedule(for rule: Rule) -> DeviceActivitySchedule {
+        // Usage-limit rules count selected activity across the current day.
+        if rule.ruleKind == .usageLimit {
+            return dailyUsageLimitSchedule()
+        }
+
         // Uses a non-repeating schedule for a one-time rule.
         if rule.isOneTime {
             // Creates one exact calendar interval for iOS to monitor.
@@ -192,6 +207,11 @@ enum FocusLockSchedule {
 
     // Calculates how many minutes the rule lasts.
     static func durationMinutes(for rule: Rule) -> Int {
+        // Usage-limit rules store their allowed daily screen time directly.
+        if rule.ruleKind == .usageLimit {
+            return rule.usageLimitMinutes ?? 0
+        }
+
         // Converts the start time into minutes after midnight.
         let startMinutes = minutesSinceMidnight(rule.startTime)
 
@@ -216,6 +236,11 @@ enum FocusLockSchedule {
 
     // Checks whether a one-time rule has already finished.
     static func isCompletedOneTimeRule(_ rule: Rule, now: Date = Date()) -> Bool {
+        // Usage-limit rules reset daily instead of completing once.
+        guard rule.ruleKind == .scheduled else {
+            return false
+        }
+
         // Recurring rules never complete once.
         guard rule.isOneTime else {
             // Tells the caller this is not a completed one-time rule.
@@ -234,6 +259,11 @@ enum FocusLockSchedule {
 
     // Builds display text that explains how a rule repeats.
     static func recurrenceSummary(for rule: Rule) -> String {
+        // Usage-limit rules reset every day.
+        if rule.ruleKind == .usageLimit {
+            return "Daily usage limit"
+        }
+
         // Handles one-time rules first.
         if rule.isOneTime {
             // Checks whether the one-time rule has a saved date.
@@ -278,6 +308,55 @@ enum FocusLockSchedule {
 
         // Joins labels into text like "Mon, Wed, Fri".
         return labels.joined(separator: ", ")
+    }
+
+    // Checks whether a usage-limit rule has reached its limit during the current day.
+    static func hasReachedUsageLimitToday(_ rule: Rule, now: Date = Date()) -> Bool {
+        // Only usage-limit rules use usageLimitReachedAt.
+        guard rule.ruleKind == .usageLimit else {
+            return false
+        }
+
+        // Reads the last threshold date.
+        guard let reachedAt = rule.usageLimitReachedAt else {
+            return false
+        }
+
+        // The rule blocks only for the calendar day when the threshold was reached.
+        return Calendar.current.isDate(reachedAt, inSameDayAs: now)
+    }
+
+    // Returns a copy of rules with stale usage-limit reached flags cleared.
+    static func clearingExpiredUsageLimitState(from rules: [Rule], now: Date = Date()) -> [Rule] {
+        rules.map { rule in
+            var cleanedRule = rule
+
+            guard cleanedRule.ruleKind == .usageLimit,
+                  let reachedAt = cleanedRule.usageLimitReachedAt,
+                  !Calendar.current.isDate(reachedAt, inSameDayAs: now) else {
+                return cleanedRule
+            }
+
+            cleanedRule.usageLimitReachedAt = nil
+            return cleanedRule
+        }
+    }
+
+    // Builds the daily threshold event for a usage-limit rule.
+    static func usageLimitEvent(for rule: Rule) -> DeviceActivityEvent? {
+        // Usage-limit rules need a positive minute threshold.
+        guard rule.ruleKind == .usageLimit,
+              let usageLimitMinutes = rule.usageLimitMinutes,
+              usageLimitMinutes >= minimumMonitorDurationMinutes else {
+            return nil
+        }
+
+        return DeviceActivityEvent(
+            applications: rule.activitySelection.applicationTokens,
+            categories: rule.activitySelection.categoryTokens,
+            webDomains: rule.activitySelection.webDomainTokens,
+            threshold: DateComponents(minute: usageLimitMinutes)
+        )
     }
 
     // Checks whether a one-time rule is active right now.
@@ -459,6 +538,15 @@ enum FocusLockSchedule {
         // Builds the smaller DateComponents value DeviceActivity expects.
         return DateComponents(hour: components.hour, minute: components.minute)
     }
+
+    // Creates a repeating all-day schedule for daily usage limits.
+    private static func dailyUsageLimitSchedule() -> DeviceActivitySchedule {
+        DeviceActivitySchedule(
+            intervalStart: DateComponents(hour: 0, minute: 0),
+            intervalEnd: DateComponents(hour: 23, minute: 59),
+            repeats: true
+        )
+    }
 }
 
 // Adds Focus Lock helpers to Apple's DeviceActivityName type.
@@ -490,6 +578,32 @@ extension DeviceActivityName {
         let idString = rawValue.replacingOccurrences(of: Self.focusLockRulePrefix, with: "")
 
         // Converts the UUID text back into a UUID value.
+        return UUID(uuidString: idString)
+    }
+}
+
+// Adds Focus Lock helpers to Apple's DeviceActivityEvent.Name type.
+extension DeviceActivityEvent.Name {
+    // Stores the prefix used for every Focus Lock usage-limit threshold event.
+    private static let focusLockUsageLimitPrefix = "focus-lock-usage-limit-"
+
+    // Builds a DeviceActivityEvent.Name from a rule id.
+    init(usageLimitRuleID: UUID) {
+        self.init(Self.focusLockUsageLimitPrefix + usageLimitRuleID.uuidString)
+    }
+
+    // Checks whether this event belongs to a Focus Lock usage-limit rule.
+    var isFocusLockUsageLimitEvent: Bool {
+        rawValue.hasPrefix(Self.focusLockUsageLimitPrefix)
+    }
+
+    // Pulls the original rule id back out of the event name.
+    var focusLockUsageLimitRuleID: UUID? {
+        guard isFocusLockUsageLimitEvent else {
+            return nil
+        }
+
+        let idString = rawValue.replacingOccurrences(of: Self.focusLockUsageLimitPrefix, with: "")
         return UUID(uuidString: idString)
     }
 }

--- a/focus-lock/Shared/Rule.swift
+++ b/focus-lock/Shared/Rule.swift
@@ -12,6 +12,15 @@ import Foundation
 // selected from Apple's Screen Time picker.
 import FamilyControls
 
+// Describes how a rule decides when selected apps should be blocked.
+enum RuleKind: String, Codable {
+    // Scheduled rules use the existing start/end time window behavior.
+    case scheduled
+
+    // Usage limit rules block after the selected apps have been used for a daily limit.
+    case usageLimit
+}
+
 // A Rule is one saved blocking rule in our app.
 //
 // Example:
@@ -30,6 +39,9 @@ struct Rule: Identifiable, Hashable, Codable {
 
     // Whether the rule is turned on or off in the UI.
     var isEnabled: Bool
+
+    // Whether this rule is a scheduled time window or a daily usage limit.
+    var ruleKind: RuleKind = .scheduled
 
     // The date/time when this rule was first created.
     // Date() means "right now" when the Rule is created.
@@ -51,6 +63,17 @@ struct Rule: Identifiable, Hashable, Codable {
     // We mostly use activitySelection.applicationTokens right now.
     // An ApplicationToken is Apple's privacy-preserving way to represent a selected app.
     var activitySelection: FamilyActivitySelection = FamilyActivitySelection()
+
+    // The amount of selected-app usage allowed each day before a usage-limit rule blocks.
+    //
+    // Scheduled rules leave this as nil.
+    var usageLimitMinutes: Int?
+
+    // The date/time when this usage-limit rule most recently reached its daily limit.
+    //
+    // If this date is today, the selected apps should stay blocked until the next day
+    // unless the user disables the rule.
+    var usageLimitReachedAt: Date?
     
     // Stores which weekdays this rule repeats on.
         // Swift Calendar weekday numbers are usually:
@@ -90,5 +113,67 @@ struct Rule: Identifiable, Hashable, Codable {
     // We only hash the ID because the ID is the rule's identity.
     func hash(into hasher: inout Hasher) {
         hasher.combine(id)
+    }
+
+    // Keeps old saved rules working when new fields are added.
+    //
+    // Without this custom decoder, older rules.json files would fail to load because they
+    // do not contain ruleKind, usageLimitMinutes, or usageLimitReachedAt.
+    enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case isEnabled
+        case ruleKind
+        case createdAt
+        case startTime
+        case endTime
+        case activitySelection
+        case usageLimitMinutes
+        case usageLimitReachedAt
+        case repeatWeekdays
+        case oneTimeDate
+    }
+
+    init(id: UUID = UUID(),
+         title: String,
+         isEnabled: Bool,
+         ruleKind: RuleKind = .scheduled,
+         createdAt: Date = Date(),
+         startTime: Date = Calendar.current.date(from: .init(hour: 9, minute: 0))!,
+         endTime: Date = Calendar.current.date(from: .init(hour: 17, minute: 0))!,
+         activitySelection: FamilyActivitySelection = FamilyActivitySelection(),
+         usageLimitMinutes: Int? = nil,
+         usageLimitReachedAt: Date? = nil,
+         repeatWeekdays: Set<Int> = Rule.allWeekdays,
+         oneTimeDate: Date? = nil) {
+        self.id = id
+        self.title = title
+        self.isEnabled = isEnabled
+        self.ruleKind = ruleKind
+        self.createdAt = createdAt
+        self.startTime = startTime
+        self.endTime = endTime
+        self.activitySelection = activitySelection
+        self.usageLimitMinutes = usageLimitMinutes
+        self.usageLimitReachedAt = usageLimitReachedAt
+        self.repeatWeekdays = repeatWeekdays
+        self.oneTimeDate = oneTimeDate
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        id = try container.decodeIfPresent(UUID.self, forKey: .id) ?? UUID()
+        title = try container.decode(String.self, forKey: .title)
+        isEnabled = try container.decode(Bool.self, forKey: .isEnabled)
+        ruleKind = try container.decodeIfPresent(RuleKind.self, forKey: .ruleKind) ?? .scheduled
+        createdAt = try container.decodeIfPresent(Date.self, forKey: .createdAt) ?? Date()
+        startTime = try container.decodeIfPresent(Date.self, forKey: .startTime) ?? Calendar.current.date(from: .init(hour: 9, minute: 0))!
+        endTime = try container.decodeIfPresent(Date.self, forKey: .endTime) ?? Calendar.current.date(from: .init(hour: 17, minute: 0))!
+        activitySelection = try container.decodeIfPresent(FamilyActivitySelection.self, forKey: .activitySelection) ?? FamilyActivitySelection()
+        usageLimitMinutes = try container.decodeIfPresent(Int.self, forKey: .usageLimitMinutes)
+        usageLimitReachedAt = try container.decodeIfPresent(Date.self, forKey: .usageLimitReachedAt)
+        repeatWeekdays = try container.decodeIfPresent(Set<Int>.self, forKey: .repeatWeekdays) ?? Rule.allWeekdays
+        oneTimeDate = try container.decodeIfPresent(Date.self, forKey: .oneTimeDate)
     }
 }

--- a/focus-lock/focus-lock/ContentView.swift
+++ b/focus-lock/focus-lock/ContentView.swift
@@ -8,13 +8,17 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var isAuthed = false
+    // Login is temporarily bypassed so the app opens straight to the main tabs.
+    // @State private var isAuthed = false
     
     // Reads the shared app state created by focus_lockApp.
     @EnvironmentObject private var appState: AppState
 
     var body: some View {
+        // Login screen temporarily disabled.
+        /*
         if isAuthed {
+        */
             TabView {
                 NavigationStack {
                     HomeView()
@@ -40,11 +44,13 @@ struct ContentView: View {
             // Inject the shared state into the entire tab hierarchy.
             // Any child view can access it with @EnvironmentObject var appState: AppState
             .environmentObject(appState)
+        /*
         } else {
             AuthView(isAuthed: $isAuthed)
                 // Optional: also inject appState here if the auth flow needs it.
                 .environmentObject(appState)
         }
+        */
     }
 }
 

--- a/focus-lock/focus-lock/DeviceActivityScheduleManager.swift
+++ b/focus-lock/focus-lock/DeviceActivityScheduleManager.swift
@@ -66,29 +66,51 @@ final class DeviceActivityScheduleManager {
 
         // Registers or updates every rule that should be monitored.
         for rule in monitorableRules {
-            // Pulls the start hour and minute from the rule.
-            let startComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.startTime)
-
-            // Pulls the end hour and minute from the rule.
-            let endComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.endTime)
-
             // Builds the unique DeviceActivity name for this rule.
             let activityName = DeviceActivityName(ruleID: rule.id)
 
-            // Records the schedule registration details for debugging.
-            FocusLockDiagnostics.record(
-                "ScheduleManager registering rule \(rule.id) as \(activityName.rawValue), start=\(startComponents.hour ?? -1):\(startComponents.minute ?? -1), end=\(endComponents.hour ?? -1):\(endComponents.minute ?? -1), selectedApps=\(rule.activitySelection.applicationTokens.count), recurrence=\(FocusLockSchedule.recurrenceSummary(for: rule))."
-            )
-
             // Starts a block that can catch schedule registration errors.
             do {
-                // Tells iOS to monitor this rule's schedule.
-                try center.startMonitoring(
-                    // Passes the unique name for this rule's schedule.
-                    activityName,
-                    // Passes either a repeating or one-time schedule.
-                    during: FocusLockSchedule.schedule(for: rule)
-                )
+                if rule.ruleKind == .usageLimit {
+                    // Build the daily usage threshold event for this rule.
+                    guard let usageLimitEvent = FocusLockSchedule.usageLimitEvent(for: rule) else {
+                        FocusLockDiagnostics.record("ScheduleManager could not build usage-limit event for rule \(rule.id).")
+                        continue
+                    }
+
+                    let eventName = DeviceActivityEvent.Name(usageLimitRuleID: rule.id)
+
+                    FocusLockDiagnostics.record(
+                        "ScheduleManager registering usage-limit rule \(rule.id) as \(activityName.rawValue), event=\(eventName.rawValue), limitMinutes=\(rule.usageLimitMinutes ?? 0), selectedApps=\(rule.activitySelection.applicationTokens.count), selectedCategories=\(rule.activitySelection.categoryTokens.count), selectedWebDomains=\(rule.activitySelection.webDomainTokens.count)."
+                    )
+
+                    // Tells iOS to count selected activity and call the monitor extension
+                    // when the threshold is reached inside the daily schedule.
+                    try center.startMonitoring(
+                        activityName,
+                        during: FocusLockSchedule.schedule(for: rule),
+                        events: [eventName: usageLimitEvent]
+                    )
+                } else {
+                    // Pulls the start hour and minute from the rule.
+                    let startComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.startTime)
+
+                    // Pulls the end hour and minute from the rule.
+                    let endComponents = Calendar.current.dateComponents([.hour, .minute], from: rule.endTime)
+
+                    // Records the schedule registration details for debugging.
+                    FocusLockDiagnostics.record(
+                        "ScheduleManager registering scheduled rule \(rule.id) as \(activityName.rawValue), start=\(startComponents.hour ?? -1):\(startComponents.minute ?? -1), end=\(endComponents.hour ?? -1):\(endComponents.minute ?? -1), selectedApps=\(rule.activitySelection.applicationTokens.count), recurrence=\(FocusLockSchedule.recurrenceSummary(for: rule))."
+                    )
+
+                    // Tells iOS to monitor this rule's schedule.
+                    try center.startMonitoring(
+                        // Passes the unique name for this rule's schedule.
+                        activityName,
+                        // Passes either a repeating or one-time schedule.
+                        during: FocusLockSchedule.schedule(for: rule)
+                    )
+                }
 
                 // Records that iOS accepted the schedule.
                 FocusLockDiagnostics.record("ScheduleManager successfully registered \(activityName.rawValue).")

--- a/focus-lock/focus-lock/State/AppState.swift
+++ b/focus-lock/focus-lock/State/AppState.swift
@@ -54,6 +54,25 @@ final class AppState: ObservableObject {
         // Note: saving, schedule registration, and shield refresh happen automatically
         // because of 'didSet' on the 'rules' variable.
     }
+
+    // Creates a daily usage-limit rule.
+    //
+    // Example:
+    // "Allow 30 minutes of Instagram today, then block it until tomorrow."
+    func addUsageLimitRule(title: String,
+                           usageLimitMinutes: Int,
+                           activitySelection: FamilyActivitySelection) {
+        let newRule = Rule(
+            title: title,
+            isEnabled: true,
+            ruleKind: .usageLimit,
+            activitySelection: activitySelection,
+            usageLimitMinutes: usageLimitMinutes,
+            usageLimitReachedAt: nil
+        )
+
+        rules.append(newRule)
+    }
     
     func toggleRule(id: UUID) {
         guard let index = rules.firstIndex(where: { $0.id == id }) else {
@@ -106,15 +125,22 @@ final class AppState: ObservableObject {
         
         // Removes one-time rules that have already completed.
         let activeRules = savedRules.filter { !FocusLockSchedule.isCompletedOneTimeRule($0) }
+
+        // Clears usage-limit reached state from previous days.
+        let cleanedRules = FocusLockSchedule.clearingExpiredUsageLimitState(from: activeRules)
         
         // Checks whether any completed one-time rules were removed.
-        if activeRules.count != savedRules.count {
+        let didCleanUsageLimitState = zip(activeRules, cleanedRules).contains { oldRule, newRule in
+            oldRule.usageLimitReachedAt != newRule.usageLimitReachedAt
+        }
+
+        if activeRules.count != savedRules.count || didCleanUsageLimitState {
             // Saves the cleaned rule list back to App Group storage.
-            FocusLockRuleStore.saveRules(activeRules)
+            FocusLockRuleStore.saveRules(cleanedRules)
         }
         
         // Gives callers the cleaned list of rules.
-        return activeRules
+        return cleanedRules
     }
     
     func deleteRule(id:UUID){
@@ -152,6 +178,9 @@ final class AppState: ObservableObject {
         // Replace the old title with the new title from the edit form.
             rules[index].title = title
 
+            // Make sure this rule uses scheduled time-window behavior.
+            rules[index].ruleKind = .scheduled
+
             // Replace the old start time with the new start time from the edit form.
             rules[index].startTime = start
 
@@ -167,8 +196,30 @@ final class AppState: ObservableObject {
             // Replace the old one-time date with the new one-time date from the edit form.
             rules[index].oneTimeDate = savedOneTimeDate
 
+            // Scheduled rules do not use daily usage-limit state.
+            rules[index].usageLimitMinutes = nil
+            rules[index].usageLimitReachedAt = nil
+
             // Because rules is @Published and has didSet, changing this rule automatically saves and syncs it.
         
+    }
+
+    // Updates an existing daily usage-limit rule.
+    func editUsageLimitRule(id: UUID,
+                            title: String,
+                            usageLimitMinutes: Int,
+                            activitySelection: FamilyActivitySelection) {
+        guard let index = rules.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+
+        rules[index].title = title
+        rules[index].ruleKind = .usageLimit
+        rules[index].activitySelection = activitySelection
+        rules[index].usageLimitMinutes = usageLimitMinutes
+
+        // If the user changes the allowed time or selected apps, let the rule start fresh.
+        rules[index].usageLimitReachedAt = nil
     }
 
     private func persistAndSyncRules() {

--- a/focus-lock/focus-lock/State/AppState.swift
+++ b/focus-lock/focus-lock/State/AppState.swift
@@ -222,6 +222,19 @@ final class AppState: ObservableObject {
         rules[index].usageLimitReachedAt = nil
     }
 
+    // Manually blocks a usage-limit rule for the rest of today.
+    //
+    // This is useful when the user knows they already used too much time before
+    // Focus Lock started monitoring this rule.
+    func blockUsageLimitRuleForToday(id: UUID) {
+        guard let index = rules.firstIndex(where: { $0.id == id }),
+              rules[index].ruleKind == .usageLimit else {
+            return
+        }
+
+        rules[index].usageLimitReachedAt = Date()
+    }
+
     private func persistAndSyncRules() {
         // 1. Save the latest rules to shared storage.
         //

--- a/focus-lock/focus-lock/Views/CreateRuleView.swift
+++ b/focus-lock/focus-lock/Views/CreateRuleView.swift
@@ -117,6 +117,10 @@ struct CreateRuleView: View {
                             TextField("Minutes", value: $customUsageLimitMinutes, format: .number)
                                 .keyboardType(.numberPad)
                         }
+
+                        Text("Today starts counting when this rule is saved. Future days reset daily.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 } else {
                     Section("Schedule") {

--- a/focus-lock/focus-lock/Views/CreateRuleView.swift
+++ b/focus-lock/focus-lock/Views/CreateRuleView.swift
@@ -13,8 +13,12 @@ struct CreateRuleView: View {
     @EnvironmentObject var appState: AppState
 
     @State private var ruleName = ""
+    @State private var ruleKind: RuleKind = .scheduled
     @State private var startTime = Calendar.current.date(from: .init(hour: 9, minute: 0))!
     @State private var endTime = Calendar.current.date(from: .init(hour: 17, minute: 0))!
+    @State private var selectedUsageLimitMinutes = 30
+    @State private var customUsageLimitMinutes = 30
+    @State private var isUsingCustomUsageLimit = false
     // Stores the weekdays selected for repeating this rule.
     @State private var repeatWeekdays = Rule.allWeekdays
     // Stores the calendar date used when no repeat weekdays are selected.
@@ -73,6 +77,16 @@ struct CreateRuleView: View {
         repeatWeekdays.isEmpty
     }
 
+    // Returns the selected daily usage limit.
+    private var usageLimitMinutes: Int {
+        isUsingCustomUsageLimit ? customUsageLimitMinutes : selectedUsageLimitMinutes
+    }
+
+    // Returns true when the user is creating a usage-limit rule.
+    private var isUsageLimitRule: Bool {
+        ruleKind == .usageLimit
+    }
+
 
 
     var body: some View {
@@ -80,37 +94,61 @@ struct CreateRuleView: View {
             Form {
                 Section("Rule Details") {
                     TextField("Rule Name", text: $ruleName)
-                }
 
-                Section("Schedule") {
-                    DatePicker("Start Time", selection: $startTime, displayedComponents: .hourAndMinute)
-
-                    DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
-                    
-                    // Shows a date picker only when the rule is one-time.
-                    if isOneTimeRule {
-                        // Lets the user choose the exact date for the one-time rule.
-                        DatePicker("Date", selection: $oneTimeDate, displayedComponents: .date)
+                    Picker("Rule Type", selection: $ruleKind) {
+                        Text("Schedule").tag(RuleKind.scheduled)
+                        Text("Usage Limit").tag(RuleKind.usageLimit)
                     }
+                    .pickerStyle(.segmented)
                 }
-                
-                // Lets the user open repeat settings from one clean row.
-                Section("Repeat") {
-                    // Opens the repeat settings sheet when tapped.
-                    Button {
-                        // Shows the repeat settings sheet.
-                        showRepeatSettings = true
-                    } label: {
-                        // Places the row title and current repeat summary side by side.
-                        HStack {
-                            // Shows the row title.
-                            Text("Repeat")
-                            // Pushes the summary to the right side.
-                            Spacer()
-                            // Shows the current recurrence choice.
-                            Text(repeatSummary)
-                                // Styles the summary as secondary text.
-                                .foregroundStyle(.secondary)
+
+                if isUsageLimitRule {
+                    Section("Daily Limit") {
+                        Picker("Duration", selection: $selectedUsageLimitMinutes) {
+                            Text("15 min").tag(15)
+                            Text("30 min").tag(30)
+                            Text("1 hour").tag(60)
+                        }
+                        .disabled(isUsingCustomUsageLimit)
+
+                        Toggle("Custom Duration", isOn: $isUsingCustomUsageLimit)
+
+                        if isUsingCustomUsageLimit {
+                            TextField("Minutes", value: $customUsageLimitMinutes, format: .number)
+                                .keyboardType(.numberPad)
+                        }
+                    }
+                } else {
+                    Section("Schedule") {
+                        DatePicker("Start Time", selection: $startTime, displayedComponents: .hourAndMinute)
+
+                        DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
+                        
+                        // Shows a date picker only when the rule is one-time.
+                        if isOneTimeRule {
+                            // Lets the user choose the exact date for the one-time rule.
+                            DatePicker("Date", selection: $oneTimeDate, displayedComponents: .date)
+                        }
+                    }
+                    
+                    // Lets the user open repeat settings from one clean row.
+                    Section("Repeat") {
+                        // Opens the repeat settings sheet when tapped.
+                        Button {
+                            // Shows the repeat settings sheet.
+                            showRepeatSettings = true
+                        } label: {
+                            // Places the row title and current repeat summary side by side.
+                            HStack {
+                                // Shows the row title.
+                                Text("Repeat")
+                                // Pushes the summary to the right side.
+                                Spacer()
+                                // Shows the current recurrence choice.
+                                Text(repeatSummary)
+                                    // Styles the summary as secondary text.
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }
@@ -140,6 +178,22 @@ struct CreateRuleView: View {
 
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
+                        if isUsageLimitRule {
+                            if usageLimitMinutes < FocusLockSchedule.minimumMonitorDurationMinutes {
+                                showDurationAlert = true
+                                return
+                            }
+
+                            appState.addUsageLimitRule(
+                                title: ruleName,
+                                usageLimitMinutes: usageLimitMinutes,
+                                activitySelection: activitySelection
+                            )
+
+                            dismiss()
+                            return
+                        }
+
                         // Create a temporary rule so we can reuse the same duration helper
                         // that the schedule manager uses before saving anything.
                         let draftRule = Rule(

--- a/focus-lock/focus-lock/Views/EditRuleView.swift
+++ b/focus-lock/focus-lock/Views/EditRuleView.swift
@@ -185,6 +185,10 @@ struct EditRuleView: View {
                             TextField("Minutes", value: $customUsageLimitMinutes, format: .number)
                                 .keyboardType(.numberPad)
                         }
+
+                        Text("Today starts counting when this rule is saved. Future days reset daily.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
                     }
                 } else {
                     // Groups the time pickers under a Schedule heading.

--- a/focus-lock/focus-lock/Views/EditRuleView.swift
+++ b/focus-lock/focus-lock/Views/EditRuleView.swift
@@ -23,6 +23,9 @@ struct EditRuleView: View {
     // Stores the editable rule name while the user types.
     @State private var ruleName: String
 
+    // Stores whether this rule is scheduled or a daily usage limit.
+    @State private var ruleKind: RuleKind
+
     // Stores the editable start time while the user changes it.
     @State private var startTime: Date
 
@@ -37,6 +40,15 @@ struct EditRuleView: View {
     
     // Stores the editable date for a one-time rule.
     @State private var oneTimeDate: Date
+
+    // Stores the selected preset daily usage limit.
+    @State private var selectedUsageLimitMinutes: Int
+
+    // Stores the custom daily usage limit.
+    @State private var customUsageLimitMinutes: Int
+
+    // Tracks whether the custom duration control is active.
+    @State private var isUsingCustomUsageLimit: Bool
 
     // Tracks whether Apple's Screen Time picker should be visible.
     @State private var showAppPicker = false
@@ -94,6 +106,16 @@ struct EditRuleView: View {
         repeatWeekdays.isEmpty
     }
 
+    // Returns the selected daily usage limit.
+    private var usageLimitMinutes: Int {
+        isUsingCustomUsageLimit ? customUsageLimitMinutes : selectedUsageLimitMinutes
+    }
+
+    // Returns true when the user is editing a usage-limit rule.
+    private var isUsageLimitRule: Bool {
+        ruleKind == .usageLimit
+    }
+
 
 
     // Runs when this edit screen is created with a specific rule.
@@ -103,6 +125,9 @@ struct EditRuleView: View {
 
         // Fills the text field with the rule's current title.
         _ruleName = State(initialValue: rule.title)
+
+        // Fills the rule type picker with the rule's current kind.
+        _ruleKind = State(initialValue: rule.ruleKind)
 
         // Fills the start picker with the rule's current start time.
         _startTime = State(initialValue: rule.startTime)
@@ -118,6 +143,13 @@ struct EditRuleView: View {
         
         // Fills the one-time date picker with the saved date, or today if there is no saved date yet.
         _oneTimeDate = State(initialValue: rule.oneTimeDate ?? Date())
+
+        let savedUsageLimitMinutes = rule.usageLimitMinutes ?? 30
+        let presetUsageLimitMinutes = [15, 30, 60].contains(savedUsageLimitMinutes) ? savedUsageLimitMinutes : 30
+
+        _selectedUsageLimitMinutes = State(initialValue: presetUsageLimitMinutes)
+        _customUsageLimitMinutes = State(initialValue: max(savedUsageLimitMinutes, FocusLockSchedule.minimumMonitorDurationMinutes))
+        _isUsingCustomUsageLimit = State(initialValue: ![15, 30, 60].contains(savedUsageLimitMinutes))
     }
 
     // Describes the UI that appears inside the edit sheet.
@@ -130,40 +162,64 @@ struct EditRuleView: View {
                 Section("Rule Details") {
                     // Lets the user change the rule name.
                     TextField("Rule Name", text: $ruleName)
-                }
 
-                // Groups the time pickers under a Schedule heading.
-                Section("Schedule") {
-                    // Lets the user change the start time.
-                    DatePicker("Start Time", selection: $startTime, displayedComponents: .hourAndMinute)
-
-                    // Lets the user change the end time.
-                    DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
-                    
-                    // Shows a date picker only when the edited rule is one-time.
-                    if isOneTimeRule {
-                        // Lets the user choose the exact date for the one-time rule.
-                        DatePicker("Date", selection: $oneTimeDate, displayedComponents: .date)
+                    Picker("Rule Type", selection: $ruleKind) {
+                        Text("Schedule").tag(RuleKind.scheduled)
+                        Text("Usage Limit").tag(RuleKind.usageLimit)
                     }
+                    .pickerStyle(.segmented)
                 }
-                
-                // Groups recurrence controls under a Repeat heading.
-                Section("Repeat") {
-                    // Opens the repeat settings sheet when tapped.
-                    Button {
-                        // Shows the repeat settings sheet.
-                        showRepeatSettings = true
-                    } label: {
-                        // Places the row title and current repeat summary side by side.
-                        HStack {
-                            // Shows the row title.
-                            Text("Repeat")
-                            // Pushes the summary to the right side.
-                            Spacer()
-                            // Shows the current recurrence choice.
-                            Text(repeatSummary)
-                                // Styles the summary as secondary text.
-                                .foregroundStyle(.secondary)
+
+                if isUsageLimitRule {
+                    Section("Daily Limit") {
+                        Picker("Duration", selection: $selectedUsageLimitMinutes) {
+                            Text("15 min").tag(15)
+                            Text("30 min").tag(30)
+                            Text("1 hour").tag(60)
+                        }
+                        .disabled(isUsingCustomUsageLimit)
+
+                        Toggle("Custom Duration", isOn: $isUsingCustomUsageLimit)
+
+                        if isUsingCustomUsageLimit {
+                            TextField("Minutes", value: $customUsageLimitMinutes, format: .number)
+                                .keyboardType(.numberPad)
+                        }
+                    }
+                } else {
+                    // Groups the time pickers under a Schedule heading.
+                    Section("Schedule") {
+                        // Lets the user change the start time.
+                        DatePicker("Start Time", selection: $startTime, displayedComponents: .hourAndMinute)
+
+                        // Lets the user change the end time.
+                        DatePicker("End Time", selection: $endTime, displayedComponents: .hourAndMinute)
+                        
+                        // Shows a date picker only when the edited rule is one-time.
+                        if isOneTimeRule {
+                            // Lets the user choose the exact date for the one-time rule.
+                            DatePicker("Date", selection: $oneTimeDate, displayedComponents: .date)
+                        }
+                    }
+                    
+                    // Groups recurrence controls under a Repeat heading.
+                    Section("Repeat") {
+                        // Opens the repeat settings sheet when tapped.
+                        Button {
+                            // Shows the repeat settings sheet.
+                            showRepeatSettings = true
+                        } label: {
+                            // Places the row title and current repeat summary side by side.
+                            HStack {
+                                // Shows the row title.
+                                Text("Repeat")
+                                // Pushes the summary to the right side.
+                                Spacer()
+                                // Shows the current recurrence choice.
+                                Text(repeatSummary)
+                                    // Styles the summary as secondary text.
+                                    .foregroundStyle(.secondary)
+                            }
                         }
                     }
                 }
@@ -209,6 +265,23 @@ struct EditRuleView: View {
                 // Places this item where Save actions normally appear.
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Save") {
+                        if isUsageLimitRule {
+                            if usageLimitMinutes < FocusLockSchedule.minimumMonitorDurationMinutes {
+                                showDurationAlert = true
+                                return
+                            }
+
+                            appState.editUsageLimitRule(
+                                id: rule.id,
+                                title: ruleName,
+                                usageLimitMinutes: usageLimitMinutes,
+                                activitySelection: activitySelection
+                            )
+
+                            dismiss()
+                            return
+                        }
+
                         // Create a temporary version of the edited rule so we can check the
                         // new start/end time before changing the saved rule.
                         let draftRule = Rule(

--- a/focus-lock/focus-lock/Views/HomeView.swift
+++ b/focus-lock/focus-lock/Views/HomeView.swift
@@ -408,7 +408,7 @@ struct HomeView: View {
     private func nextUpcomingRule(now: Date) -> UpcomingRule? {
         appState.rules
             // Ignore rules that cannot actually be scheduled or shield anything.
-            .filter { FocusLockSchedule.isMonitorable($0, now: now) }
+            .filter { $0.ruleKind == .scheduled && FocusLockSchedule.isMonitorable($0, now: now) }
             .compactMap { rule -> UpcomingRule? in
                 // Some rules may not have a future start.
                 // Example: a one-time rule whose start already passed.
@@ -478,6 +478,11 @@ struct HomeView: View {
     //
     // This powers the "Scheduled today" tile.
     private func isScheduledToday(_ rule: Rule, now: Date) -> Bool {
+        // Usage-limit rules are available daily, but they do not have a clock start time.
+        guard rule.ruleKind == .scheduled else {
+            return false
+        }
+
         // If iOS would not monitor this rule, we should not count it as scheduled.
         guard FocusLockSchedule.isMonitorable(rule, now: now) else {
             return false

--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -57,7 +57,7 @@ struct RulesView: View {
             case .active:
                 return "Blocking distractions right now"
             case .limitAvailable:
-                return "Will block after the daily limit is reached"
+                return "Counting from when this rule was saved today"
             case .scheduled:
                 return "Will turn on at the next scheduled time"
             case .disabled:
@@ -302,6 +302,17 @@ struct RulesView: View {
                                 Text(selectedActivitySummary(for: rule))
                                     .font(.caption)
                                     .foregroundStyle(.secondary)
+
+                                if shouldShowBlockForTodayButton(for: rule, now: timeline.date) {
+                                    Button {
+                                        appState.blockUsageLimitRuleForToday(id: rule.id)
+                                    } label: {
+                                        Label("Block for Today", systemImage: "lock.fill")
+                                            .font(.caption.weight(.semibold))
+                                    }
+                                    .buttonStyle(.bordered)
+                                    .controlSize(.small)
+                                }
                             }
                             .padding(14)
                             .frame(maxWidth: .infinity, alignment: .leading)
@@ -418,10 +429,18 @@ struct RulesView: View {
                 return "\(limitMinutes) min limit reached. Blocked until tomorrow."
             }
 
-            return "\(limitMinutes) min daily limit"
+            return "\(limitMinutes) min limit. Counts from now today, then resets daily."
         }
 
         return "\(rule.startTime.formatted(date: .omitted, time: .shortened)) - \(rule.endTime.formatted(date: .omitted, time: .shortened))"
+    }
+
+    // Shows the manual block action only when a usage-limit rule is ready but not blocked yet.
+    private func shouldShowBlockForTodayButton(for rule: Rule, now: Date) -> Bool {
+        rule.ruleKind == .usageLimit &&
+        rule.isEnabled &&
+        invalidReason(for: rule) == nil &&
+        !FocusLockSchedule.hasReachedUsageLimitToday(rule, now: now)
     }
 
     // Finds the next future start time for a rule.

--- a/focus-lock/focus-lock/Views/RulesView.swift
+++ b/focus-lock/focus-lock/Views/RulesView.swift
@@ -15,7 +15,8 @@ struct RulesView: View {
     
     @State private var ruleBeingEdited: Rule?
     
-    @State private var goToBlocked = false
+    // Blocked screen shortcut temporarily hidden from the Rules page.
+    // @State private var goToBlocked = false
 
     // Describes the user-facing state shown on each rule row.
     //
@@ -24,6 +25,7 @@ struct RulesView: View {
     // this enum would be a good candidate to move into Shared/.
     private enum RuleDisplayStatus {
         case active
+        case limitAvailable
         case scheduled
         case disabled
         case invalid(String)
@@ -34,6 +36,8 @@ struct RulesView: View {
             switch self {
             case .active:
                 return "Active now"
+            case .limitAvailable:
+                return "Available today"
             case .scheduled:
                 return "Scheduled"
             case .disabled:
@@ -52,6 +56,8 @@ struct RulesView: View {
             switch self {
             case .active:
                 return "Blocking distractions right now"
+            case .limitAvailable:
+                return "Will block after the daily limit is reached"
             case .scheduled:
                 return "Will turn on at the next scheduled time"
             case .disabled:
@@ -68,6 +74,8 @@ struct RulesView: View {
             switch self {
             case .active:
                 return "lock.shield.fill"
+            case .limitAvailable:
+                return "hourglass"
             case .scheduled:
                 return "clock.fill"
             case .disabled:
@@ -84,6 +92,8 @@ struct RulesView: View {
             switch self {
             case .active:
                 return .green
+            case .limitAvailable:
+                return .blue
             case .scheduled:
                 return .orange
             case .disabled:
@@ -103,6 +113,8 @@ struct RulesView: View {
             switch self {
             case .active:
                 return .green
+            case .limitAvailable:
+                return .blue
             case .scheduled:
                 return .orange
             case .invalid:
@@ -120,6 +132,8 @@ struct RulesView: View {
             switch self {
             case .active:
                 return .green
+            case .limitAvailable:
+                return .blue
             case .scheduled:
                 return .orange
             default:
@@ -139,7 +153,7 @@ struct RulesView: View {
                 return 0
             case .invalid, .disabled, .completed:
                 return 1
-            case .scheduled:
+            case .limitAvailable, .scheduled:
                 return 2
             }
         }
@@ -274,7 +288,7 @@ struct RulesView: View {
                                     .font(.caption)
                                     .foregroundStyle(status.tint)
                                 
-                                Text("\(rule.startTime, style: .time) - \(rule.endTime, style: .time)")
+                                Text(primaryScheduleText(for: rule, now: timeline.date))
                                     .font(.subheadline)
                                     .foregroundStyle(.gray)
                                 
@@ -313,13 +327,17 @@ struct RulesView: View {
                 }
             }
             
+            /*
             FocusButton(title: "Blocked Screen") {
                 goToBlocked = true
             }
+            */
         }.padding(20)
+        /*
         .navigationDestination(isPresented: $goToBlocked) {
             BlockedView()
         }
+        */
     }
 
     // Builds the compact colored status pill shown under the rule title.
@@ -359,6 +377,10 @@ struct RulesView: View {
             return .active
         }
 
+        if rule.ruleKind == .usageLimit {
+            return .limitAvailable
+        }
+
         if nextStartDate(for: rule, after: now) != nil {
             return .scheduled
         }
@@ -373,6 +395,10 @@ struct RulesView: View {
         }
 
         if FocusLockSchedule.durationMinutes(for: rule) < FocusLockSchedule.minimumMonitorDurationMinutes {
+            if rule.ruleKind == .usageLimit {
+                return "Daily limit must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes"
+            }
+
             return "Rule must be at least \(FocusLockSchedule.minimumMonitorDurationMinutes) minutes long"
         }
 
@@ -381,6 +407,21 @@ struct RulesView: View {
         }
 
         return nil
+    }
+
+    // Builds the main time/limit text for a rule card.
+    private func primaryScheduleText(for rule: Rule, now: Date) -> String {
+        if rule.ruleKind == .usageLimit {
+            let limitMinutes = rule.usageLimitMinutes ?? 0
+
+            if FocusLockSchedule.hasReachedUsageLimitToday(rule, now: now) {
+                return "\(limitMinutes) min limit reached. Blocked until tomorrow."
+            }
+
+            return "\(limitMinutes) min daily limit"
+        }
+
+        return "\(rule.startTime.formatted(date: .omitted, time: .shortened)) - \(rule.endTime.formatted(date: .omitted, time: .shortened))"
     }
 
     // Finds the next future start time for a rule.


### PR DESCRIPTION
Summary
Adds usage-limit rules alongside the existing scheduled rule flow, plus a manual “Block for Today” override.

Why
Users often want to limit actual app usage, not just block apps during fixed clock windows. A rule like “15 minutes of Clash Royale” should allow usage until the selected threshold is reached, then block the app for the rest of the day.

Apple’s Screen Time APIs do not reliably expose already-used app time to the main app when a rule is created, so this PR uses a clear MVP behavior: usage limits count from when the rule is saved today, then reset daily going forward.

Changes
Adds scheduled vs usage-limit rule types.
Persists usage-limit minutes and reached-at state.
Keeps existing scheduled rules intact.
Registers DeviceActivity threshold events for usage-limit rules.
Handles `eventDidReachThreshold` in the DeviceActivity monitor extension.
Blocks selected apps after the usage threshold is reached.
Resets usage-limit reached state on the next day.
Adds Usage Limit controls to Create Rule and Edit Rule.
Supports preset durations and custom minute entry.
Adds “Block for Today” to manually block a usage-limit rule immediately.
Clarifies usage-limit copy in Create, Edit, and Rules screens.
Updates Home so usage-limit rules are not shown as clock-scheduled upcoming blocks.
Bypasses the login screen so the app opens directly to the main tabs.
Comments out the Rules page “Blocked Screen” shortcut.

Privacy Notes
DeviceActivity threshold events can tell the monitor extension when a selected usage threshold is reached, but Focus Lock cannot reliably query already-used per-app Screen Time at rule creation time. Raw Screen Time usage data remains protected by Apple’s Screen Time privacy model.

Verification
Generic iOS Debug build passes:

```sh
xcodebuild -quiet -project focus-lock.xcodeproj -scheme focus-lock -configuration Debug -destination generic/platform=iOS -derivedDataPath /private/tmp/focus-lock-derived-data CODE_SIGNING_ALLOWED=NO build