### PR TITLE
Add quick focus session

### DIFF
--- a/focus-lock/focus-lock/State/AppState.swift
+++ b/focus-lock/focus-lock/State/AppState.swift
@@ -73,6 +73,36 @@ final class AppState: ObservableObject {
 
         rules.append(newRule)
     }
+
+    // Starts an immediate one-time focus session from the Home screen.
+    //
+    // This intentionally reuses the existing scheduled rule model instead of adding
+    // a separate session type. That means the same persistence, DeviceActivity
+    // registration, immediate shield sync, and completed one-time cleanup all apply.
+    func startQuickFocusSession(durationMinutes: Int,
+                                activitySelection: FamilyActivitySelection,
+                                now: Date = Date()) {
+        guard durationMinutes >= FocusLockSchedule.minimumMonitorDurationMinutes else {
+            return
+        }
+
+        guard let endTime = Calendar.current.date(byAdding: .minute, value: durationMinutes, to: now) else {
+            return
+        }
+
+        let quickFocusRule = Rule(
+            title: "Quick Focus",
+            isEnabled: true,
+            ruleKind: .scheduled,
+            startTime: now,
+            endTime: endTime,
+            activitySelection: activitySelection,
+            repeatWeekdays: [],
+            oneTimeDate: now
+        )
+
+        rules.append(quickFocusRule)
+    }
     
     func toggleRule(id: UUID) {
         guard let index = rules.firstIndex(where: { $0.id == id }) else {

--- a/focus-lock/focus-lock/Views/HomeView.swift
+++ b/focus-lock/focus-lock/Views/HomeView.swift
@@ -26,6 +26,12 @@ struct HomeView: View {
     // When this becomes true, SwiftUI presents the sheet attached below.
     @State private var showCreateSheet = false
 
+    // Controls whether the quick focus sheet is open.
+    //
+    // Quick focus starts a one-time rule immediately instead of making the
+    // user build a permanent schedule first.
+    @State private var showQuickFocusSheet = false
+
     var body: some View {
         // TimelineView refreshes the dashboard every 60 seconds.
         //
@@ -45,7 +51,7 @@ struct HomeView: View {
                     // The big top status card: active now, next scheduled, or no active block.
                     protectionStatusSection(now: timeline.date)
 
-                    // Main action button for creating a new blocking rule.
+                    // Main actions for starting protection or creating a reusable rule.
                     primaryAction
 
                     // Small stat tiles based on saved rules.
@@ -68,6 +74,9 @@ struct HomeView: View {
             // Presents the existing CreateRuleView when the primary button sets showCreateSheet = true.
             .sheet(isPresented: $showCreateSheet) {
                 CreateRuleView()
+            }
+            .sheet(isPresented: $showQuickFocusSheet) {
+                QuickFocusView()
             }
         }
     }
@@ -141,23 +150,35 @@ struct HomeView: View {
 
     // MARK: - Primary Action
 
-    // The main Home action.
+    // The main Home actions.
     //
-    // MVP 1 should make the user's next step obvious, and right now that step is creating a rule.
+    // Start Focus is the fastest path to immediate protection. Create Rule remains
+    // available for reusable schedules and daily usage limits.
     private var primaryAction: some View {
-        Button {
-            // Tells SwiftUI to present CreateRuleView as a sheet.
-            showCreateSheet = true
-        } label: {
-            // Label combines an SF Symbol with text.
-            // This is more scannable than text alone.
-            Label("Create Rule", systemImage: "plus.circle.fill")
-                .font(.headline)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
+        VStack(spacing: 10) {
+            Button {
+                showQuickFocusSheet = true
+            } label: {
+                Label("Start Focus", systemImage: "bolt.fill")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 14)
+            }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.large)
+
+            Button {
+                // Tells SwiftUI to present CreateRuleView as a sheet.
+                showCreateSheet = true
+            } label: {
+                Label("Create Rule", systemImage: "plus.circle.fill")
+                    .font(.headline)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.large)
         }
-        .buttonStyle(.borderedProminent)
-        .controlSize(.large)
     }
 
     // MARK: - Today Summary

--- a/focus-lock/focus-lock/Views/QuickFocusView.swift
+++ b/focus-lock/focus-lock/Views/QuickFocusView.swift
@@ -1,0 +1,118 @@
+//
+//  QuickFocusView.swift
+//  focus-lock
+//
+
+import FamilyControls
+import SwiftUI
+
+struct QuickFocusView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var appState: AppState
+
+    @State private var selectedDurationMinutes = 30
+    @State private var activitySelection = FamilyActivitySelection()
+    @State private var showAppPicker = false
+
+    private let durationOptions = [
+        QuickFocusDuration(minutes: 15, title: "15 min"),
+        QuickFocusDuration(minutes: 30, title: "30 min"),
+        QuickFocusDuration(minutes: 60, title: "1 hour"),
+        QuickFocusDuration(minutes: 120, title: "2 hours")
+    ]
+
+    private var selectedActivitySummary: String {
+        let appCount = activitySelection.applicationTokens.count
+        let categoryCount = activitySelection.categoryTokens.count
+        let webDomainCount = activitySelection.webDomainTokens.count
+
+        var parts: [String] = []
+
+        if appCount > 0 {
+            parts.append("\(appCount) \(appCount == 1 ? "app" : "apps")")
+        }
+
+        if categoryCount > 0 {
+            parts.append("\(categoryCount) \(categoryCount == 1 ? "category" : "categories")")
+        }
+
+        if webDomainCount > 0 {
+            parts.append("\(webDomainCount) \(webDomainCount == 1 ? "website" : "websites")")
+        }
+
+        return parts.isEmpty ? "None selected" : parts.joined(separator: ", ") + " selected"
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                Section {
+                    Picker("Duration", selection: $selectedDurationMinutes) {
+                        ForEach(durationOptions) { option in
+                            Text(option.title).tag(option.minutes)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+
+                    Text("Starts now and removes itself when the session ends.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } header: {
+                    Text("Duration")
+                }
+
+                Section("Apps") {
+                    Button {
+                        showAppPicker = true
+                    } label: {
+                        HStack {
+                            Text("Select Apps")
+                            Spacer()
+                            Text(selectedActivitySummary)
+                                .foregroundStyle(.secondary)
+                                .multilineTextAlignment(.trailing)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Start Focus")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Start") {
+                        appState.startQuickFocusSession(
+                            durationMinutes: selectedDurationMinutes,
+                            activitySelection: activitySelection
+                        )
+                        dismiss()
+                    }
+                    .disabled(!FocusLockSchedule.hasSelectedActivity(activitySelection))
+                }
+            }
+            .familyActivityPicker(
+                isPresented: $showAppPicker,
+                selection: $activitySelection
+            )
+        }
+    }
+}
+
+private struct QuickFocusDuration: Identifiable {
+    let minutes: Int
+    let title: String
+
+    var id: Int {
+        minutes
+    }
+}
+
+#Preview {
+    QuickFocusView()
+        .environmentObject(AppState())
+}


### PR DESCRIPTION
## Summary
Adds a Home-based quick focus flow so users can start immediate one-time blocking sessions without creating a reusable rule manually.

## Changes
- Adds a `Start Focus` entry point on Home.
- Adds a compact quick focus sheet with 15 min, 30 min, 1 hour, and 2 hour presets.
- Lets users pick apps, categories, and websites with the Screen Time picker.
- Creates a one-time scheduled `Quick Focus` rule that starts immediately and ends after the chosen duration.
- Reuses existing rule persistence, DeviceActivity scheduling, immediate shield sync, and one-time cleanup behavior.

## Verification
Generic iOS Debug build passes:

```bash
xcodebuild -project focus-lock/focus-lock.xcodeproj -scheme focus-lock -configuration Debug -destination generic/platform=iOS -derivedDataPath /private/tmp/focus-lock-quick-focus-derived CODE_SIGNING_ALLOWED=NO build
```

Installed and tested launch path on Shabarish's iPhone with direct `devicectl` install.

## Real-Device Test Plan
- Start a 15-minute quick focus session from Home.
- Confirm selected apps block immediately.
- Background/close Focus Lock normally and confirm blocking remains.
- Confirm session appears as active in Rules.
- Confirm it ends automatically and does not unblock apps still covered by another active rule.
- Confirm completed quick focus session disappears from Rules after end/reopen.
- Test overlapping scheduled rule plus quick focus on the same app.

Closes #42